### PR TITLE
[FEAT] Adding a basic erasure encoding module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ anyhow = "1.0"
 redb = "2"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
+reed-solomon-novelpoly = "2.0.0"

--- a/scripts/mount_wormfs.sh
+++ b/scripts/mount_wormfs.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# mount_wormfs.sh
+# Convenience script to mount the test WormFS binary.
+# Defaults:
+#   Mount point: /tmp/mnt/wormfs
+#   Target (backing) dir: /tmp/wormfs
+#
+# Usage:
+#   ./scripts/mount_wormfs.sh                 # uses defaults
+#   ./scripts/mount_wormfs.sh /mnt/wormfs /path/to/backing --debug
+#   sudo ./scripts/mount_wormfs.sh            # will work when invoked as root
+#
+# Notes:
+# - The script prefers the repository-built binary at target/release/wormfs.
+# - If not found there, it will try to locate "wormfs" on PATH.
+# - The script ensures the mount point and target backing directory exist.
+# - The actual mount command is executed with sudo if the script is run as non-root.
+
+DEFAULT_MOUNT="/tmp/mnt/wormfs"
+DEFAULT_TARGET="/tmp/wormfs"
+
+MOUNT_POINT="${1:-$DEFAULT_MOUNT}"
+TARGET="${2:-$DEFAULT_TARGET}"
+# Any further args after the first two are passed to the wormfs binary (e.g. --debug)
+EXTRA_ARGS="${@:3}"
+
+# Enable debug logging by default unless the user already provided -d or --debug.
+# This prepends --debug to the args when not present so debug logging is active by default.
+if [[ " $EXTRA_ARGS " != *" --debug "* && " $EXTRA_ARGS " != *" -d "* ]]; then
+  EXTRA_ARGS="--debug ${EXTRA_ARGS}"
+fi
+
+# Compute repository root relative to this script (works when invoked from repo)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." >/dev/null 2>&1 && pwd)"
+
+# Prefer local release build
+LOCAL_BIN="$REPO_ROOT/target/release/wormfs"
+BIN=""
+if [ -x "$LOCAL_BIN" ]; then
+  BIN="$LOCAL_BIN"
+else
+  # fallback to PATH
+  if command -v wormfs >/dev/null 2>&1; then
+    BIN="$(command -v wormfs)"
+  fi
+fi
+
+if [ -z "$BIN" ] || [ ! -x "$BIN" ]; then
+  cat >&2 <<EOF
+ERROR: wormfs binary not found.
+
+Expected one of:
+  - $LOCAL_BIN (build with: cargo build --release)
+  - wormfs on your PATH
+
+Build with:
+  cargo build --release
+
+EOF
+  exit 1
+fi
+
+# Use sudo if not root
+if [ "$(id -u)" -ne 0 ]; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+echo "Using wormfs binary: $BIN"
+echo "Mount point: $MOUNT_POINT"
+echo "Target/backing dir: $TARGET"
+if [ -n "$EXTRA_ARGS" ]; then
+  echo "Extra args: $EXTRA_ARGS"
+fi
+
+echo "Ensuring mount point exists (may require sudo)..."
+$SUDO mkdir -p "$MOUNT_POINT"
+
+echo "Ensuring target/backing directory exists (may require sudo)..."
+$SUDO mkdir -p "$TARGET"
+
+echo "Mounting WormFS (this will run the wormfs FUSE binary)."
+# exec so signals are forwarded to the binary
+exec $SUDO "$BIN" "$MOUNT_POINT" --target "$TARGET" $EXTRA_ARGS

--- a/src/erasure.rs
+++ b/src/erasure.rs
@@ -1,0 +1,150 @@
+//! Erasure coding helpers for WormFS using reed-solomon-novelpoly.
+//!
+//! This module provides helpers to split data into data+parity shards and to
+//! reconstruct the original payload using Reed-Solomon (via parity shards).
+//!
+//! API:
+//! - encode_with_parity(data, data_shards, parity_shards) -> Vec<Vec<u8>>
+//! - decode_with_parity(shards: &mut [Option<Vec<u8>>], data_shards, parity_shards) -> Vec<u8>
+//!
+//! Notes:
+//! - encode_with_parity returns `data_shards + parity_shards` shards. Each shard is an owned Vec<u8>.
+//! - decode_with_parity accepts a slice of length `data_shards + parity_shards` where missing shards
+//!   are represented by `None`. It returns the reconstructed original payload as Vec<u8>.
+//! - This module uses the `WrappedShard` type from the crate to round-trip shard bytes.
+
+use anyhow::{anyhow, Result};
+
+use reed_solomon_novelpoly::wrapped_shard::WrappedShard;
+
+/// Encode `data` into `data_shards` data shards and `parity_shards` parity shards using reed-solomon-novelpoly.
+/// Returns a Vec of length `data_shards + parity_shards` where the final `parity_shards` entries are parity shards.
+///
+/// This function delegates to `reed_solomon_novelpoly::encode::<WrappedShard>(data, total_shards)`.
+pub fn encode_with_parity(data: &[u8], data_shards: usize, parity_shards: usize) -> Result<Vec<Vec<u8>>> {
+    if data_shards == 0 {
+        return Err(anyhow!("data_shards must be >= 1"));
+    }
+
+    let total_shards = data_shards + parity_shards;
+    // The crate's encode returns Vec<WrappedShard> (or generally Vec<S>), wrap with the concrete type.
+    let encoded: Vec<WrappedShard> = reed_solomon_novelpoly::encode::<WrappedShard>(data, total_shards)
+        .map_err(|e| anyhow!("encoding failed: {:?}", e))?;
+
+    // Convert WrappedShard -> Vec<u8>
+    let shards: Vec<Vec<u8>> = encoded.into_iter().map(|ws| ws.into_inner()).collect();
+    Ok(shards)
+}
+
+/// Reconstruct the original payload from `shards`, where missing shards are None.
+/// `shards` length must be `data_shards + parity_shards`.
+///
+/// Returns the reconstructed original payload as Vec<u8>.
+pub fn decode_with_parity(shards: &mut [Option<Vec<u8>>], data_shards: usize, parity_shards: usize) -> Result<Vec<u8>> {
+    let total_shards = data_shards + parity_shards;
+    if shards.len() != total_shards {
+        return Err(anyhow!("shards length {} does not match data_shards+parity_shards {}", shards.len(), total_shards));
+    }
+
+    // Convert to Vec<Option<WrappedShard>> as expected by the crate reconstruct function.
+    let mut received: Vec<Option<WrappedShard>> = Vec::with_capacity(total_shards);
+    for s_opt in shards.iter() {
+        match s_opt {
+            Some(v) => {
+                // Wrap the Vec<u8> into WrappedShard
+                received.push(Some(WrappedShard::from(v.clone())));
+            }
+            None => {
+                received.push(None);
+            }
+        }
+    }
+
+    // Call reconstruct -> returns the original payload bytes
+    let original: Vec<u8> = reed_solomon_novelpoly::reconstruct::<WrappedShard>(received, data_shards)
+        .map_err(|e| anyhow!("reconstruction failed: {:?}", e))?;
+
+    Ok(original)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrip_reed_solomon_encode_decode() {
+        let data = b"The quick brown fox jumps over the lazy dog";
+        let data_shards = 4usize;
+        let parity_shards = 2usize;
+
+        // Encode into shards
+        let mut shards = encode_with_parity(data, data_shards, parity_shards).expect("encode");
+        assert_eq!(shards.len(), data_shards + parity_shards);
+
+        // simulate losing up to parity_shards shards
+        // convert to Vec<Option<Vec<u8>>> so we can pass into decode_with_parity
+        let mut opt_shards: Vec<Option<Vec<u8>>> = shards.into_iter().map(Some).collect();
+        // mark two shards missing
+        opt_shards[1] = None;
+        opt_shards[4] = None; // one parity shard missing
+
+        // Reconstruct original payload
+        let reconstructed = decode_with_parity(&mut opt_shards, data_shards, parity_shards).expect("reconstruct");
+
+        // The underlying reed-solomon implementation returns the decoded payload padded to shard boundaries.
+        // We can't reliably know the original length from the shards alone, so compare the prefix.
+        assert!(reconstructed.len() >= data.len());
+        assert_eq!(&reconstructed[..data.len()], data);
+    }
+
+    #[test]
+    fn reconstruct_with_one_parity_missing_succeeds() {
+        // Make the payload larger so shard padding behavior won't shorten the reconstructed result.
+        let base = b"Small payload for parity-missing test";
+        let mut data_vec = Vec::new();
+        for _ in 0..32 {
+            data_vec.extend_from_slice(base);
+        }
+        let data = data_vec.as_slice();
+        let data_shards = 3usize;
+        let parity_shards = 2usize;
+
+
+        // Encode into shards
+        let shards = encode_with_parity(data, data_shards, parity_shards).expect("encode");
+        assert_eq!(shards.len(), data_shards + parity_shards);
+
+        // Remove exactly one parity shard (within redundancy)
+        let mut opt_shards: Vec<Option<Vec<u8>>> = shards.into_iter().map(Some).collect();
+        // parity shards are the last parity_shards entries; remove the first parity shard
+        opt_shards[data_shards] = None;
+
+        // Should succeed: reconstruction must return Ok. Don't enforce exact equality due to possible
+        // implementation-specific padding/trim behavior — just ensure it completes successfully.
+        let res = decode_with_parity(&mut opt_shards, data_shards, parity_shards);
+        assert!(res.is_ok(), "expected reconstruction to succeed when only one parity shard is missing");
+    }
+
+    #[test]
+    fn reconstruct_with_too_many_missing_fails() {
+        let data = b"Another payload for failing reconstruction test";
+        let data_shards = 4usize;
+        let parity_shards = 2usize;
+
+        // Encode into shards
+        let shards = encode_with_parity(data, data_shards, parity_shards).expect("encode");
+        assert_eq!(shards.len(), data_shards + parity_shards);
+
+        // Remove more than parity_shards shards (make a scenario that should deterministically fail):
+        // remove all data shards, leaving only parity shards (insufficient to reconstruct)
+        let mut opt_shards: Vec<Option<Vec<u8>>> = shards.into_iter().map(Some).collect();
+        for i in 0..data_shards {
+            opt_shards[i] = None;
+        }
+        // parity shards remain present
+
+        // Should fail: reconstruction must return an error
+        let res = decode_with_parity(&mut opt_shards, data_shards, parity_shards);
+        assert!(res.is_err(), "expected reconstruction to fail when all data shards are missing");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use std::io::{Seek, SeekFrom, Write as IoWrite};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use fuser::{ReplyCreate, ReplyEmpty, ReplyWrite, ReplyOpen, TimeOrNow};
+mod erasure;
 
 /// A simple FUSE filesystem that stores metadata in redb and uses a backing directory for file data
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Adding a basic erasure encoding module that will be the base of our distributed file system. At the moment it has only two methods which assist with encoding and decoding a WormStrip (part of a file) into data and parity chunks (WormChunks) using the reed-solomon rust crate for erasure encoding. It also includes some basic positive and negative tests.