### PR TITLE
Phase 1C: Multi-Disk Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4295,6 +4295,7 @@ dependencies = [
  "criterion",
  "fuser",
  "futures",
+ "libc",
  "libp2p",
  "once_cell",
  "proptest",
@@ -4316,6 +4317,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,13 @@ bytes = "1.0"
 futures = "0.3"
 once_cell = "1.19"
 
+# System calls (for disk space checking)
+libc = "0.2"
+
+# Windows API (for disk space checking on Windows)
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["fileapi", "winbase"] }
+
 # Web interface
 axum = "0.7"
 tower = "0.4"

--- a/config/storage_node.yaml
+++ b/config/storage_node.yaml
@@ -7,8 +7,44 @@ node_id: "550e8400-e29b-41d4-a716-446655440000"
 # Path to the SQLite metadata database
 metadata_db_path: "data/metadata.db"
 
-# Root directory for chunk storage
-storage_root: "data/chunks"
+# Storage configuration
+storage_config:
+  # OPTION 1: Single disk mode (backward compatibility)
+  # Uncomment the line below for single-disk setup
+  # storage_root: "data/chunks"
+  
+  # OPTION 2: Multi-disk mode (recommended for production)
+  # Multi-disk configuration for enhanced reliability and performance
+  disks:
+    - disk_id: "primary"
+      path: "data/chunks/disk1"
+      min_free_space: 1073741824  # 1GB
+    - disk_id: "secondary"
+      path: "data/chunks/disk2"  
+      min_free_space: 1073741824  # 1GB
+    - disk_id: "tertiary"
+      path: "data/chunks/disk3"
+      min_free_space: 1073741824  # 1GB
+
+# Disk monitoring configuration
+disk_monitoring:
+  # Interval between disk health checks (seconds)
+  check_interval_seconds: 30
+  # Number of consecutive failures before marking disk offline
+  failure_threshold_consecutive: 3
+  # Percentage of disk usage that triggers space alerts
+  space_alert_threshold_percent: 90
+
+# Chunk placement configuration
+chunk_placement:
+  # Minimum number of disks required for chunk placement
+  min_disks_required: 1
+  # Whether to prefer disks with more available space
+  prefer_more_space: true
+  # Maximum attempts to find placement before giving up
+  max_placement_attempts: 10
+  # Whether to allow degraded placement (fewer disks than chunks)
+  allow_degraded_placement: false
 
 # Erasure coding configuration
 erasure_config:
@@ -18,9 +54,6 @@ erasure_config:
   parity_shards: 2
   # Target stripe size in bytes (1MB default)
   stripe_size: 1048576
-
-# Minimum free space required before rejecting new chunks (1GB default)
-min_free_space: 1073741824
 
 # Maximum file size to accept (100GB default)
 max_file_size: 107374182400

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -156,7 +156,7 @@ This implementation plan breaks down WormFS development into small, manageable p
 
 ---
 
-#### **Phase 1C: Multi-Disk Support (1-2 weeks)**
+#### **Phase 1C: Multi-Disk Support (1-2 weeks)** COMPLETED
 **Goal:** Add support for multiple storage devices per node
 
 **Deliverables:**

--- a/src/chunk_placement.rs
+++ b/src/chunk_placement.rs
@@ -1,0 +1,691 @@
+//! Chunk Placement Strategy Module
+//!
+//! This module implements intelligent chunk placement algorithms for WormFS
+//! that ensure blast radius protection (max 1 chunk per stripe per disk),
+//! load balancing across available disks, and fault tolerance.
+
+use crate::disk_manager::{DiskInfo, DiskManager};
+use crate::metadata_store::{ChunkId, StripeId};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+use tracing::{debug, warn};
+
+/// Configuration for chunk placement strategy
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkPlacementConfig {
+    /// Minimum number of disks required for placement
+    pub min_disks_required: usize,
+    /// Whether to prefer disks with more available space
+    pub prefer_more_space: bool,
+    /// Maximum attempts to find placement before giving up
+    pub max_placement_attempts: u32,
+    /// Whether to allow degraded placement (fewer disks than chunks)
+    pub allow_degraded_placement: bool,
+}
+
+impl Default for ChunkPlacementConfig {
+    fn default() -> Self {
+        Self {
+            min_disks_required: 1,
+            prefer_more_space: true,
+            max_placement_attempts: 10,
+            allow_degraded_placement: false,
+        }
+    }
+}
+
+/// Result of a chunk placement operation
+#[derive(Debug, Clone)]
+pub struct PlacementResult {
+    /// Disk assignments for each chunk index
+    pub chunk_to_disk: HashMap<u8, String>,
+    /// Disks that will be used for this placement
+    pub disks_used: HashSet<String>,
+    /// Whether this is a degraded placement (some chunks on same disk)
+    pub is_degraded: bool,
+    /// Placement quality score (0.0 = worst, 1.0 = perfect)
+    pub quality_score: f64,
+}
+
+impl PlacementResult {
+    /// Create a new placement result
+    pub fn new(chunk_to_disk: HashMap<u8, String>) -> Self {
+        let disks_used: HashSet<String> = chunk_to_disk.values().cloned().collect();
+        let is_degraded = disks_used.len() < chunk_to_disk.len();
+
+        // Calculate quality score based on distribution
+        let quality_score = if is_degraded {
+            // Degraded placement gets lower score
+            (disks_used.len() as f64) / (chunk_to_disk.len() as f64) * 0.8
+        } else {
+            // Perfect distribution gets full score
+            1.0
+        };
+
+        Self {
+            chunk_to_disk,
+            disks_used,
+            is_degraded,
+            quality_score,
+        }
+    }
+
+    /// Get the disk ID for a specific chunk index
+    pub fn get_disk_for_chunk(&self, chunk_index: u8) -> Option<&String> {
+        self.chunk_to_disk.get(&chunk_index)
+    }
+
+    /// Get the number of disks used
+    pub fn disk_count(&self) -> usize {
+        self.disks_used.len()
+    }
+
+    /// Check if placement meets minimum quality requirements
+    pub fn meets_quality_threshold(&self, threshold: f64) -> bool {
+        self.quality_score >= threshold
+    }
+}
+
+/// Information about existing chunk placements for blast radius checking
+#[derive(Debug, Clone)]
+pub struct ExistingPlacements {
+    /// Map of stripe_id to (chunk_index -> disk_id)
+    stripe_placements: HashMap<StripeId, HashMap<u8, String>>,
+}
+
+impl ExistingPlacements {
+    /// Create new empty placement tracker
+    pub fn new() -> Self {
+        Self {
+            stripe_placements: HashMap::new(),
+        }
+    }
+
+    /// Add an existing chunk placement
+    pub fn add_chunk_placement(&mut self, chunk_id: ChunkId, disk_id: String) {
+        let stripe_id = chunk_id.stripe_id();
+        self.stripe_placements
+            .entry(stripe_id)
+            .or_default()
+            .insert(chunk_id.chunk_index, disk_id);
+    }
+
+    /// Get existing placements for a stripe
+    pub fn get_stripe_placements(&self, stripe_id: StripeId) -> Option<&HashMap<u8, String>> {
+        self.stripe_placements.get(&stripe_id)
+    }
+
+    /// Check if a disk already has a chunk from this stripe
+    pub fn disk_has_chunk_from_stripe(&self, stripe_id: StripeId, disk_id: &str) -> bool {
+        if let Some(placements) = self.stripe_placements.get(&stripe_id) {
+            placements
+                .values()
+                .any(|existing_disk| existing_disk == disk_id)
+        } else {
+            false
+        }
+    }
+
+    /// Remove all placements for a stripe (for cleanup)
+    pub fn remove_stripe(&mut self, stripe_id: StripeId) {
+        self.stripe_placements.remove(&stripe_id);
+    }
+}
+
+impl Default for ExistingPlacements {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Errors that can occur during chunk placement
+#[derive(Error, Debug)]
+pub enum ChunkPlacementError {
+    #[error("No disks available for chunk placement")]
+    NoDisksAvailable,
+
+    #[error("Insufficient disks available: need {required}, have {available}")]
+    InsufficientDisks { required: usize, available: usize },
+
+    #[error("Blast radius violation: disk {disk_id} already has chunk from stripe {stripe_id}")]
+    BlastRadiusViolation {
+        disk_id: String,
+        stripe_id: StripeId,
+    },
+
+    #[error("Placement quality too low: {quality:.2} < {threshold:.2}")]
+    QualityTooLow { quality: f64, threshold: f64 },
+
+    #[error("Max placement attempts exceeded: {attempts}")]
+    MaxAttemptsExceeded { attempts: u32 },
+
+    #[error("Configuration error: {reason}")]
+    Configuration { reason: String },
+}
+
+/// Result type for chunk placement operations
+pub type ChunkPlacementResult<T> = Result<T, ChunkPlacementError>;
+
+/// Main chunk placement strategy implementation
+#[derive(Default)]
+pub struct ChunkPlacementStrategy {
+    config: ChunkPlacementConfig,
+}
+
+impl ChunkPlacementStrategy {
+    /// Create a new chunk placement strategy
+    pub fn new(config: ChunkPlacementConfig) -> ChunkPlacementResult<Self> {
+        // Validate configuration
+        if config.min_disks_required == 0 {
+            return Err(ChunkPlacementError::Configuration {
+                reason: "min_disks_required must be at least 1".to_string(),
+            });
+        }
+
+        Ok(Self { config })
+    }
+
+    /// Place chunks for a new stripe across available disks
+    pub fn place_stripe_chunks(
+        &self,
+        stripe_id: StripeId,
+        chunk_count: usize,
+        disk_manager: &DiskManager,
+        existing_placements: &ExistingPlacements,
+    ) -> ChunkPlacementResult<PlacementResult> {
+        debug!(
+            "Placing {} chunks for stripe {} across available disks",
+            chunk_count, stripe_id
+        );
+
+        let available_disks = disk_manager.get_available_disks();
+
+        if available_disks.is_empty() {
+            return Err(ChunkPlacementError::NoDisksAvailable);
+        }
+
+        if available_disks.len() < self.config.min_disks_required {
+            return Err(ChunkPlacementError::InsufficientDisks {
+                required: self.config.min_disks_required,
+                available: available_disks.len(),
+            });
+        }
+
+        // Filter out disks that already have chunks from this stripe
+        let eligible_disks: Vec<&DiskInfo> = available_disks
+            .into_iter()
+            .filter(|disk| {
+                !existing_placements.disk_has_chunk_from_stripe(stripe_id, &disk.disk_id)
+            })
+            .collect();
+
+        debug!(
+            "Found {} eligible disks for placement",
+            eligible_disks.len()
+        );
+
+        if eligible_disks.is_empty() {
+            return Err(ChunkPlacementError::NoDisksAvailable);
+        }
+
+        // Check if we can achieve perfect placement (one chunk per disk)
+        let perfect_placement_possible = eligible_disks.len() >= chunk_count;
+
+        if !perfect_placement_possible && !self.config.allow_degraded_placement {
+            return Err(ChunkPlacementError::InsufficientDisks {
+                required: chunk_count,
+                available: eligible_disks.len(),
+            });
+        }
+
+        // Attempt placement with multiple strategies
+        for attempt in 0..self.config.max_placement_attempts {
+            match self.attempt_placement(chunk_count, &eligible_disks, attempt) {
+                Ok(placement) => {
+                    debug!(
+                        "Successful placement on attempt {}: {} disks used, quality {:.2}",
+                        attempt + 1,
+                        placement.disk_count(),
+                        placement.quality_score
+                    );
+                    return Ok(placement);
+                }
+                Err(e) => {
+                    debug!("Placement attempt {} failed: {}", attempt + 1, e);
+                    continue;
+                }
+            }
+        }
+
+        Err(ChunkPlacementError::MaxAttemptsExceeded {
+            attempts: self.config.max_placement_attempts,
+        })
+    }
+
+    /// Attempt to place chunks using a specific strategy
+    fn attempt_placement(
+        &self,
+        chunk_count: usize,
+        eligible_disks: &[&DiskInfo],
+        attempt: u32,
+    ) -> ChunkPlacementResult<PlacementResult> {
+        let mut chunk_to_disk = HashMap::new();
+
+        // Sort disks by preferred criteria
+        let mut sorted_disks = eligible_disks.to_vec();
+        self.sort_disks_by_preference(&mut sorted_disks, attempt);
+
+        // Assign chunks to disks
+        for chunk_index in 0..chunk_count {
+            let disk_index = if sorted_disks.len() >= chunk_count {
+                // Perfect placement: one chunk per disk
+                chunk_index % sorted_disks.len()
+            } else {
+                // Degraded placement: distribute as evenly as possible
+                self.calculate_degraded_disk_index(chunk_index, sorted_disks.len(), chunk_count)
+            };
+
+            let selected_disk = &sorted_disks[disk_index];
+            chunk_to_disk.insert(chunk_index as u8, selected_disk.disk_id.clone());
+        }
+
+        let placement = PlacementResult::new(chunk_to_disk);
+
+        // Validate placement quality if this is not a degraded placement attempt
+        if !self.config.allow_degraded_placement && placement.is_degraded {
+            return Err(ChunkPlacementError::QualityTooLow {
+                quality: placement.quality_score,
+                threshold: 1.0,
+            });
+        }
+
+        Ok(placement)
+    }
+
+    /// Sort disks according to placement preferences and attempt number
+    fn sort_disks_by_preference(&self, disks: &mut Vec<&DiskInfo>, attempt: u32) {
+        match attempt {
+            0 => {
+                // First attempt: prefer disks with more available space
+                if self.config.prefer_more_space {
+                    disks.sort_by(|a, b| b.available_space.cmp(&a.available_space));
+                }
+            }
+            1 => {
+                // Second attempt: prefer disks with less usage percentage
+                disks.sort_by(|a, b| {
+                    a.usage_percentage()
+                        .partial_cmp(&b.usage_percentage())
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+            }
+            2 => {
+                // Third attempt: randomize order (using disk_id as pseudo-random)
+                disks.sort_by(|a, b| a.disk_id.cmp(&b.disk_id));
+            }
+            _ => {
+                // Subsequent attempts: reverse previous order
+                disks.reverse();
+            }
+        }
+    }
+
+    /// Calculate disk index for degraded placement to distribute chunks evenly
+    fn calculate_degraded_disk_index(
+        &self,
+        chunk_index: usize,
+        disk_count: usize,
+        chunk_count: usize,
+    ) -> usize {
+        // Use round-robin distribution to spread chunks as evenly as possible
+        (chunk_index * disk_count) / chunk_count
+    }
+
+    /// Validate an existing placement against blast radius rules
+    pub fn validate_placement(
+        &self,
+        stripe_id: StripeId,
+        placement: &PlacementResult,
+        existing_placements: &ExistingPlacements,
+    ) -> ChunkPlacementResult<()> {
+        // Check blast radius: no disk should have more than one chunk from same stripe
+        let mut disk_chunk_count = HashMap::new();
+
+        for disk_id in placement.chunk_to_disk.values() {
+            *disk_chunk_count.entry(disk_id).or_insert(0) += 1;
+
+            // Check against existing placements
+            if existing_placements.disk_has_chunk_from_stripe(stripe_id, disk_id) {
+                return Err(ChunkPlacementError::BlastRadiusViolation {
+                    disk_id: disk_id.clone(),
+                    stripe_id,
+                });
+            }
+        }
+
+        // Verify no disk gets more than one chunk in this placement
+        for (disk_id, count) in disk_chunk_count {
+            if count > 1 {
+                warn!(
+                    "Blast radius violation in placement: disk {} assigned {} chunks from stripe {}",
+                    disk_id, count, stripe_id
+                );
+                return Err(ChunkPlacementError::BlastRadiusViolation {
+                    disk_id: disk_id.clone(),
+                    stripe_id,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get placement statistics for monitoring
+    pub fn get_placement_stats(&self, placements: &[PlacementResult]) -> PlacementStats {
+        if placements.is_empty() {
+            return PlacementStats::default();
+        }
+
+        let total_placements = placements.len();
+        let degraded_placements = placements.iter().filter(|p| p.is_degraded).count();
+        let perfect_placements = total_placements - degraded_placements;
+
+        let average_quality =
+            placements.iter().map(|p| p.quality_score).sum::<f64>() / total_placements as f64;
+
+        let average_disks_used = placements.iter().map(|p| p.disk_count()).sum::<usize>() as f64
+            / total_placements as f64;
+
+        PlacementStats {
+            total_placements,
+            perfect_placements,
+            degraded_placements,
+            average_quality,
+            average_disks_used,
+        }
+    }
+
+    /// Get the configuration
+    pub fn config(&self) -> &ChunkPlacementConfig {
+        &self.config
+    }
+}
+
+/// Statistics about chunk placements
+#[derive(Debug, Clone)]
+pub struct PlacementStats {
+    /// Total number of placements analyzed
+    pub total_placements: usize,
+    /// Number of perfect placements (one chunk per disk)
+    pub perfect_placements: usize,
+    /// Number of degraded placements (multiple chunks per disk)
+    pub degraded_placements: usize,
+    /// Average quality score across all placements
+    pub average_quality: f64,
+    /// Average number of disks used per placement
+    pub average_disks_used: f64,
+}
+
+impl Default for PlacementStats {
+    fn default() -> Self {
+        Self {
+            total_placements: 0,
+            perfect_placements: 0,
+            degraded_placements: 0,
+            average_quality: 0.0,
+            average_disks_used: 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::disk_manager::{DiskConfig, DiskManager, DiskManagerConfig};
+    use tempfile::TempDir;
+    use uuid::Uuid;
+
+    fn create_test_disk_manager(disk_count: usize) -> (DiskManager, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let mut disk_configs = Vec::new();
+
+        for i in 0..disk_count {
+            let disk_id = format!("disk{}", i + 1);
+            let path = temp_dir.path().join(&disk_id);
+            std::fs::create_dir_all(&path).unwrap();
+            disk_configs.push(DiskConfig::new(disk_id, path, 1024));
+        }
+
+        let config = DiskManagerConfig::new(disk_configs);
+        let manager = DiskManager::new(config).unwrap();
+        (manager, temp_dir)
+    }
+
+    #[test]
+    fn test_chunk_placement_strategy_creation() {
+        let config = ChunkPlacementConfig::default();
+        let strategy = ChunkPlacementStrategy::new(config).unwrap();
+        assert!(strategy.config().min_disks_required >= 1);
+    }
+
+    #[test]
+    fn test_invalid_configuration() {
+        let config = ChunkPlacementConfig {
+            min_disks_required: 0,
+            ..Default::default()
+        };
+
+        let result = ChunkPlacementStrategy::new(config);
+        assert!(matches!(
+            result,
+            Err(ChunkPlacementError::Configuration { .. })
+        ));
+    }
+
+    #[test]
+    fn test_perfect_placement() {
+        let (disk_manager, _temp_dir) = create_test_disk_manager(6);
+        let strategy = ChunkPlacementStrategy::default();
+        let existing_placements = ExistingPlacements::new();
+
+        let file_id = Uuid::new_v4();
+        let stripe_id = StripeId::new(file_id, 0);
+
+        // Place 4 chunks across 6 disks - should achieve perfect placement
+        let result = strategy
+            .place_stripe_chunks(stripe_id, 4, &disk_manager, &existing_placements)
+            .unwrap();
+
+        assert!(!result.is_degraded);
+        assert_eq!(result.chunk_to_disk.len(), 4);
+        assert_eq!(result.disks_used.len(), 4);
+        assert_eq!(result.quality_score, 1.0);
+    }
+
+    #[test]
+    fn test_degraded_placement() {
+        let (disk_manager, _temp_dir) = create_test_disk_manager(2);
+        let config = ChunkPlacementConfig {
+            allow_degraded_placement: true,
+            ..Default::default()
+        };
+        let strategy = ChunkPlacementStrategy::new(config).unwrap();
+        let existing_placements = ExistingPlacements::new();
+
+        let file_id = Uuid::new_v4();
+        let stripe_id = StripeId::new(file_id, 0);
+
+        // Place 4 chunks across 2 disks - should result in degraded placement
+        let result = strategy
+            .place_stripe_chunks(stripe_id, 4, &disk_manager, &existing_placements)
+            .unwrap();
+
+        assert!(result.is_degraded);
+        assert_eq!(result.chunk_to_disk.len(), 4);
+        assert_eq!(result.disks_used.len(), 2);
+        assert!(result.quality_score < 1.0);
+    }
+
+    #[test]
+    fn test_insufficient_disks_error() {
+        let (disk_manager, _temp_dir) = create_test_disk_manager(1);
+        let config = ChunkPlacementConfig {
+            min_disks_required: 3, // Require more disks than available
+            ..Default::default()
+        };
+
+        let strategy = ChunkPlacementStrategy::new(config).unwrap();
+        let existing_placements = ExistingPlacements::new();
+
+        let file_id = Uuid::new_v4();
+        let stripe_id = StripeId::new(file_id, 0);
+
+        let result =
+            strategy.place_stripe_chunks(stripe_id, 4, &disk_manager, &existing_placements);
+
+        assert!(matches!(
+            result,
+            Err(ChunkPlacementError::InsufficientDisks { .. })
+        ));
+    }
+
+    #[test]
+    fn test_blast_radius_protection() {
+        let (disk_manager, _temp_dir) = create_test_disk_manager(4);
+        let strategy = ChunkPlacementStrategy::default();
+        let mut existing_placements = ExistingPlacements::new();
+
+        let file_id = Uuid::new_v4();
+        let stripe_id = StripeId::new(file_id, 0);
+
+        // Add existing chunk placement
+        let existing_chunk_id = ChunkId::new(file_id, 0, 0);
+        existing_placements.add_chunk_placement(existing_chunk_id, "disk1".to_string());
+
+        // Try to place 2 more chunks - should avoid disk1 and use remaining disks
+        let result = strategy
+            .place_stripe_chunks(stripe_id, 2, &disk_manager, &existing_placements)
+            .unwrap();
+
+        // Verify disk1 is not used in new placement
+        assert!(!result.disks_used.contains("disk1"));
+        assert!(
+            result.disks_used.contains("disk2")
+                || result.disks_used.contains("disk3")
+                || result.disks_used.contains("disk4")
+        );
+    }
+
+    #[test]
+    fn test_existing_placements_tracking() {
+        let mut placements = ExistingPlacements::new();
+        let file_id = Uuid::new_v4();
+        let stripe_id = StripeId::new(file_id, 0);
+        let chunk_id = ChunkId::new(file_id, 0, 0);
+
+        // Initially no placements
+        assert!(!placements.disk_has_chunk_from_stripe(stripe_id, "disk1"));
+
+        // Add placement
+        placements.add_chunk_placement(chunk_id, "disk1".to_string());
+        assert!(placements.disk_has_chunk_from_stripe(stripe_id, "disk1"));
+        assert!(!placements.disk_has_chunk_from_stripe(stripe_id, "disk2"));
+
+        // Remove stripe
+        placements.remove_stripe(stripe_id);
+        assert!(!placements.disk_has_chunk_from_stripe(stripe_id, "disk1"));
+    }
+
+    #[test]
+    fn test_placement_validation() {
+        let strategy = ChunkPlacementStrategy::default();
+        let existing_placements = ExistingPlacements::new();
+
+        let file_id = Uuid::new_v4();
+        let stripe_id = StripeId::new(file_id, 0);
+
+        // Create valid placement
+        let mut chunk_to_disk = HashMap::new();
+        chunk_to_disk.insert(0, "disk1".to_string());
+        chunk_to_disk.insert(1, "disk2".to_string());
+        let placement = PlacementResult::new(chunk_to_disk);
+
+        // Should validate successfully
+        assert!(strategy
+            .validate_placement(stripe_id, &placement, &existing_placements)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_placement_validation_blast_radius_violation() {
+        let strategy = ChunkPlacementStrategy::default();
+        let mut existing_placements = ExistingPlacements::new();
+
+        let file_id = Uuid::new_v4();
+        let stripe_id = StripeId::new(file_id, 0);
+
+        // Add existing placement
+        let existing_chunk_id = ChunkId::new(file_id, 0, 0);
+        existing_placements.add_chunk_placement(existing_chunk_id, "disk1".to_string());
+
+        // Create placement that violates blast radius
+        let mut chunk_to_disk = HashMap::new();
+        chunk_to_disk.insert(1, "disk1".to_string()); // Same disk as existing chunk
+        let placement = PlacementResult::new(chunk_to_disk);
+
+        // Should fail validation
+        let result = strategy.validate_placement(stripe_id, &placement, &existing_placements);
+        assert!(matches!(
+            result,
+            Err(ChunkPlacementError::BlastRadiusViolation { .. })
+        ));
+    }
+
+    #[test]
+    fn test_placement_stats() {
+        let strategy = ChunkPlacementStrategy::default();
+
+        // Create test placements
+        let mut placements = Vec::new();
+
+        // Perfect placement
+        let mut chunk_to_disk1 = HashMap::new();
+        chunk_to_disk1.insert(0, "disk1".to_string());
+        chunk_to_disk1.insert(1, "disk2".to_string());
+        placements.push(PlacementResult::new(chunk_to_disk1));
+
+        // Degraded placement
+        let mut chunk_to_disk2 = HashMap::new();
+        chunk_to_disk2.insert(0, "disk1".to_string());
+        chunk_to_disk2.insert(1, "disk1".to_string()); // Same disk
+        placements.push(PlacementResult::new(chunk_to_disk2));
+
+        let stats = strategy.get_placement_stats(&placements);
+
+        assert_eq!(stats.total_placements, 2);
+        assert_eq!(stats.perfect_placements, 1);
+        assert_eq!(stats.degraded_placements, 1);
+        assert!(stats.average_quality > 0.0 && stats.average_quality < 1.0);
+    }
+
+    #[test]
+    fn test_placement_result_operations() {
+        let mut chunk_to_disk = HashMap::new();
+        chunk_to_disk.insert(0, "disk1".to_string());
+        chunk_to_disk.insert(1, "disk2".to_string());
+        chunk_to_disk.insert(2, "disk1".to_string()); // Degraded: same disk
+
+        let placement = PlacementResult::new(chunk_to_disk);
+
+        assert_eq!(placement.disk_count(), 2);
+        assert!(placement.is_degraded);
+        assert!(placement.quality_score < 1.0);
+        assert_eq!(placement.get_disk_for_chunk(0), Some(&"disk1".to_string()));
+        assert_eq!(placement.get_disk_for_chunk(1), Some(&"disk2".to_string()));
+        assert_eq!(placement.get_disk_for_chunk(3), None);
+
+        assert!(placement.meets_quality_threshold(0.5));
+        assert!(!placement.meets_quality_threshold(0.9));
+    }
+}

--- a/src/disk_manager.rs
+++ b/src/disk_manager.rs
@@ -1,0 +1,701 @@
+//! Disk Manager Module
+//!
+//! This module provides disk discovery, monitoring, and management capabilities
+//! for WormFS storage nodes. It handles multiple storage devices, monitors
+//! disk health, and provides real-time space utilization information.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use thiserror::Error;
+use tracing::{debug, error, info, warn};
+
+/// Configuration for individual disk
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DiskConfig {
+    /// Unique identifier for this disk
+    pub disk_id: String,
+    /// Mount path for this disk
+    pub path: PathBuf,
+    /// Minimum free space required on this disk (in bytes)
+    pub min_free_space: u64,
+}
+
+impl DiskConfig {
+    /// Create a new disk configuration
+    pub fn new<P: Into<PathBuf>>(disk_id: String, path: P, min_free_space: u64) -> Self {
+        Self {
+            disk_id,
+            path: path.into(),
+            min_free_space,
+        }
+    }
+}
+
+/// Configuration for disk monitoring
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiskMonitoringConfig {
+    /// Interval between disk health checks (in seconds)
+    pub check_interval_seconds: u64,
+    /// Number of consecutive failures before marking disk offline
+    pub failure_threshold_consecutive: u32,
+    /// Percentage of disk usage that triggers space alerts
+    pub space_alert_threshold_percent: u8,
+}
+
+impl Default for DiskMonitoringConfig {
+    fn default() -> Self {
+        Self {
+            check_interval_seconds: 30,
+            failure_threshold_consecutive: 3,
+            space_alert_threshold_percent: 90,
+        }
+    }
+}
+
+/// Configuration for the disk manager
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiskManagerConfig {
+    /// List of configured disks
+    pub disks: Vec<DiskConfig>,
+    /// Monitoring configuration
+    pub monitoring: DiskMonitoringConfig,
+}
+
+impl DiskManagerConfig {
+    /// Create a new disk manager configuration
+    pub fn new(disks: Vec<DiskConfig>) -> Self {
+        Self {
+            disks,
+            monitoring: DiskMonitoringConfig::default(),
+        }
+    }
+
+    /// Add a disk to the configuration
+    pub fn add_disk(&mut self, disk: DiskConfig) {
+        self.disks.push(disk);
+    }
+
+    /// Get disk configuration by ID
+    pub fn get_disk_config(&self, disk_id: &str) -> Option<&DiskConfig> {
+        self.disks.iter().find(|d| d.disk_id == disk_id)
+    }
+
+    /// Validate the configuration
+    pub fn validate(&self) -> Result<(), DiskManagerError> {
+        if self.disks.is_empty() {
+            return Err(DiskManagerError::InvalidConfiguration {
+                reason: "At least one disk must be configured".to_string(),
+            });
+        }
+
+        // Check for duplicate disk IDs
+        let mut disk_ids = std::collections::HashSet::new();
+        for disk in &self.disks {
+            if !disk_ids.insert(&disk.disk_id) {
+                return Err(DiskManagerError::InvalidConfiguration {
+                    reason: format!("Duplicate disk ID: {}", disk.disk_id),
+                });
+            }
+        }
+
+        // Check for duplicate paths
+        let mut paths = std::collections::HashSet::new();
+        for disk in &self.disks {
+            if !paths.insert(&disk.path) {
+                return Err(DiskManagerError::InvalidConfiguration {
+                    reason: format!("Duplicate disk path: {:?}", disk.path),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Information about a single disk
+#[derive(Debug, Clone)]
+pub struct DiskInfo {
+    /// Disk identifier
+    pub disk_id: String,
+    /// Mount path
+    pub path: PathBuf,
+    /// Total space on disk (in bytes)
+    pub total_space: u64,
+    /// Available space on disk (in bytes)
+    pub available_space: u64,
+    /// Used space on disk (in bytes)
+    pub used_space: u64,
+    /// Whether the disk is currently online and accessible
+    pub is_online: bool,
+    /// Minimum free space required on this disk
+    pub min_free_space: u64,
+    /// Number of consecutive health check failures
+    pub consecutive_failures: u32,
+    /// Last time this disk was checked
+    pub last_checked: SystemTime,
+    /// Last error encountered (if any)
+    pub last_error: Option<String>,
+}
+
+impl DiskInfo {
+    /// Create a new disk info from configuration
+    pub fn from_config(config: &DiskConfig) -> Self {
+        Self {
+            disk_id: config.disk_id.clone(),
+            path: config.path.clone(),
+            total_space: 0,
+            available_space: 0,
+            used_space: 0,
+            is_online: false,
+            min_free_space: config.min_free_space,
+            consecutive_failures: 0,
+            last_checked: SystemTime::now(),
+            last_error: None,
+        }
+    }
+
+    /// Check if this disk has sufficient free space
+    pub fn has_sufficient_space(&self) -> bool {
+        self.is_online && self.available_space >= self.min_free_space
+    }
+
+    /// Get the percentage of disk space used
+    pub fn usage_percentage(&self) -> f64 {
+        if self.total_space == 0 {
+            return 0.0;
+        }
+        (self.used_space as f64 / self.total_space as f64) * 100.0
+    }
+
+    /// Check if disk usage is above the alert threshold
+    pub fn is_above_alert_threshold(&self, threshold_percent: u8) -> bool {
+        self.usage_percentage() > threshold_percent as f64
+    }
+
+    /// Update disk space information
+    pub fn update_space_info(&mut self, total: u64, available: u64) {
+        self.total_space = total;
+        self.available_space = available;
+        self.used_space = total.saturating_sub(available);
+        self.last_checked = SystemTime::now();
+    }
+
+    /// Mark disk as online after successful check
+    pub fn mark_online(&mut self) {
+        self.is_online = true;
+        self.consecutive_failures = 0;
+        self.last_error = None;
+        self.last_checked = SystemTime::now();
+    }
+
+    /// Mark disk as failed with error information
+    pub fn mark_failed(&mut self, error: String) {
+        self.consecutive_failures += 1;
+        self.last_error = Some(error);
+        self.last_checked = SystemTime::now();
+    }
+
+    /// Check if disk should be marked offline based on failure threshold
+    pub fn should_mark_offline(&self, threshold: u32) -> bool {
+        self.consecutive_failures >= threshold
+    }
+}
+
+/// Statistics about all disks
+#[derive(Debug, Clone)]
+pub struct DiskStats {
+    /// Total number of configured disks
+    pub total_disks: usize,
+    /// Number of online disks
+    pub online_disks: usize,
+    /// Number of offline disks
+    pub offline_disks: usize,
+    /// Total space across all disks
+    pub total_space: u64,
+    /// Total available space across all disks
+    pub total_available_space: u64,
+    /// Total used space across all disks
+    pub total_used_space: u64,
+    /// Number of disks above alert threshold
+    pub disks_above_threshold: usize,
+}
+
+impl DiskStats {
+    /// Calculate overall usage percentage
+    pub fn overall_usage_percentage(&self) -> f64 {
+        if self.total_space == 0 {
+            return 0.0;
+        }
+        (self.total_used_space as f64 / self.total_space as f64) * 100.0
+    }
+}
+
+/// Errors that can occur during disk manager operations
+#[derive(Error, Debug)]
+pub enum DiskManagerError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Invalid configuration: {reason}")]
+    InvalidConfiguration { reason: String },
+
+    #[error("Disk not found: {disk_id}")]
+    DiskNotFound { disk_id: String },
+
+    #[error("All disks offline")]
+    AllDisksOffline,
+
+    #[error("Insufficient space on all disks")]
+    InsufficientSpaceOnAllDisks,
+
+    #[error("Disk access error for {disk_id}: {error}")]
+    DiskAccessError { disk_id: String, error: String },
+}
+
+/// Result type for disk manager operations
+pub type DiskManagerResult<T> = Result<T, DiskManagerError>;
+
+/// Main disk manager implementation
+pub struct DiskManager {
+    config: DiskManagerConfig,
+    disks: HashMap<String, DiskInfo>,
+    last_global_check: SystemTime,
+}
+
+impl DiskManager {
+    /// Create a new disk manager with the given configuration
+    pub fn new(config: DiskManagerConfig) -> DiskManagerResult<Self> {
+        // Validate configuration
+        config.validate()?;
+
+        info!(
+            "Initializing disk manager with {} disks",
+            config.disks.len()
+        );
+
+        let mut disks = HashMap::new();
+        for disk_config in &config.disks {
+            let disk_info = DiskInfo::from_config(disk_config);
+            disks.insert(disk_config.disk_id.clone(), disk_info);
+            debug!(
+                "Added disk: {} at {:?}",
+                disk_config.disk_id, disk_config.path
+            );
+        }
+
+        let mut manager = Self {
+            config,
+            disks,
+            last_global_check: SystemTime::now(),
+        };
+
+        // Perform initial health check
+        manager.check_all_disks()?;
+
+        info!("Disk manager initialized successfully");
+        Ok(manager)
+    }
+
+    /// Get information about a specific disk
+    pub fn get_disk_info(&self, disk_id: &str) -> Option<&DiskInfo> {
+        self.disks.get(disk_id)
+    }
+
+    /// Get information about all disks
+    pub fn get_all_disk_info(&self) -> &HashMap<String, DiskInfo> {
+        &self.disks
+    }
+
+    /// Get a list of online disks with sufficient space
+    pub fn get_available_disks(&self) -> Vec<&DiskInfo> {
+        self.disks
+            .values()
+            .filter(|disk| disk.has_sufficient_space())
+            .collect()
+    }
+
+    /// Get a list of online disk IDs with sufficient space
+    pub fn get_available_disk_ids(&self) -> Vec<String> {
+        self.get_available_disks()
+            .into_iter()
+            .map(|disk| disk.disk_id.clone())
+            .collect()
+    }
+
+    /// Check if any disks are available for storage
+    pub fn has_available_disks(&self) -> bool {
+        !self.get_available_disks().is_empty()
+    }
+
+    /// Perform health check on all disks
+    pub fn check_all_disks(&mut self) -> DiskManagerResult<()> {
+        debug!("Performing health check on all disks");
+
+        // Collect disk info to avoid borrowing conflicts
+        let mut disk_checks = Vec::new();
+        for (disk_id, disk_info) in &self.disks {
+            disk_checks.push((disk_id.clone(), disk_info.path.clone()));
+        }
+
+        // Perform checks and update disk info
+        for (disk_id, disk_path) in disk_checks {
+            match self.get_disk_space_info(&disk_path) {
+                Ok((total, available)) => {
+                    if let Some(disk_info) = self.disks.get_mut(&disk_id) {
+                        disk_info.update_space_info(total, available);
+                        disk_info.mark_online();
+                        debug!(
+                            "Disk {} online: {:.2}% used ({} / {} bytes)",
+                            disk_id,
+                            disk_info.usage_percentage(),
+                            disk_info.used_space,
+                            disk_info.total_space
+                        );
+
+                        // Check for space alerts
+                        if disk_info.is_above_alert_threshold(
+                            self.config.monitoring.space_alert_threshold_percent,
+                        ) {
+                            warn!(
+                                "Disk {} above space alert threshold: {:.2}% used",
+                                disk_id,
+                                disk_info.usage_percentage()
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    if let Some(disk_info) = self.disks.get_mut(&disk_id) {
+                        let error_msg = format!("Failed to check disk space: {}", e);
+                        disk_info.mark_failed(error_msg.clone());
+                        debug!("Disk {} check failed: {}", disk_id, error_msg);
+
+                        // Mark disk offline if threshold reached
+                        if disk_info.should_mark_offline(
+                            self.config.monitoring.failure_threshold_consecutive,
+                        ) && disk_info.is_online
+                        {
+                            warn!(
+                                "Marking disk {} offline after {} consecutive failures",
+                                disk_id, disk_info.consecutive_failures
+                            );
+                            disk_info.is_online = false;
+                        }
+                    }
+                }
+            }
+        }
+
+        self.last_global_check = SystemTime::now();
+        Ok(())
+    }
+
+    /// Check if it's time for a health check based on configuration
+    pub fn should_check_health(&self) -> bool {
+        let check_interval = Duration::from_secs(self.config.monitoring.check_interval_seconds);
+        self.last_global_check.elapsed().unwrap_or_default() >= check_interval
+    }
+
+    /// Perform health check if needed
+    pub fn check_health_if_needed(&mut self) -> DiskManagerResult<()> {
+        if self.should_check_health() {
+            self.check_all_disks()?;
+        }
+        Ok(())
+    }
+
+    /// Get disk space information using platform-specific methods
+    fn get_disk_space_info(&self, path: &Path) -> std::io::Result<(u64, u64)> {
+        // Ensure the path exists
+        if !path.exists() {
+            fs::create_dir_all(path)?;
+        }
+
+        // Use statvfs on Unix-like systems, GetDiskFreeSpaceEx on Windows
+        #[cfg(unix)]
+        {
+            use std::ffi::CString;
+            use std::mem::MaybeUninit;
+
+            let c_path = CString::new(path.to_string_lossy().as_bytes()).map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path")
+            })?;
+
+            let mut statvfs = MaybeUninit::uninit();
+            let result = unsafe { libc::statvfs(c_path.as_ptr(), statvfs.as_mut_ptr()) };
+
+            if result == 0 {
+                let statvfs = unsafe { statvfs.assume_init() };
+                let block_size = statvfs.f_frsize;
+                let total_blocks = statvfs.f_blocks;
+                let available_blocks = statvfs.f_bavail;
+
+                let total_space = total_blocks * block_size;
+                let available_space = available_blocks * block_size;
+
+                Ok((total_space, available_space))
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        }
+
+        #[cfg(windows)]
+        {
+            use std::ffi::OsStr;
+            use std::iter::once;
+            use std::os::windows::ffi::OsStrExt;
+            use winapi::um::fileapi::GetDiskFreeSpaceExW;
+
+            let wide_path: Vec<u16> = OsStr::new(path).encode_wide().chain(once(0)).collect();
+
+            let mut available_space = 0u64;
+            let mut total_space = 0u64;
+
+            let result = unsafe {
+                GetDiskFreeSpaceExW(
+                    wide_path.as_ptr(),
+                    &mut available_space,
+                    &mut total_space,
+                    std::ptr::null_mut(),
+                )
+            };
+
+            if result != 0 {
+                Ok((total_space, available_space))
+            } else {
+                Err(std::io::Error::last_os_error())
+            }
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            // Fallback for other platforms - return placeholder values
+            warn!("Disk space checking not implemented for this platform");
+            Ok((u64::MAX / 2, u64::MAX / 4)) // Assume plenty of space
+        }
+    }
+
+    /// Get comprehensive statistics about all disks
+    pub fn get_stats(&self) -> DiskStats {
+        let total_disks = self.disks.len();
+        let online_disks = self.disks.values().filter(|d| d.is_online).count();
+        let offline_disks = total_disks - online_disks;
+
+        let (total_space, total_available_space, total_used_space, disks_above_threshold) =
+            self.disks.values().fold(
+                (0u64, 0u64, 0u64, 0usize),
+                |(total, available, used, above_threshold), disk| {
+                    let new_above_threshold = if disk.is_above_alert_threshold(
+                        self.config.monitoring.space_alert_threshold_percent,
+                    ) {
+                        above_threshold + 1
+                    } else {
+                        above_threshold
+                    };
+
+                    (
+                        total + disk.total_space,
+                        available + disk.available_space,
+                        used + disk.used_space,
+                        new_above_threshold,
+                    )
+                },
+            );
+
+        DiskStats {
+            total_disks,
+            online_disks,
+            offline_disks,
+            total_space,
+            total_available_space,
+            total_used_space,
+            disks_above_threshold,
+        }
+    }
+
+    /// Ensure a disk directory exists and is accessible
+    pub fn ensure_disk_directory(
+        &self,
+        disk_id: &str,
+        subpath: &Path,
+    ) -> DiskManagerResult<PathBuf> {
+        let disk_info = self
+            .disks
+            .get(disk_id)
+            .ok_or_else(|| DiskManagerError::DiskNotFound {
+                disk_id: disk_id.to_string(),
+            })?;
+
+        if !disk_info.is_online {
+            return Err(DiskManagerError::DiskAccessError {
+                disk_id: disk_id.to_string(),
+                error: "Disk is offline".to_string(),
+            });
+        }
+
+        let full_path = disk_info.path.join(subpath);
+
+        if !full_path.exists() {
+            fs::create_dir_all(&full_path)?;
+        }
+
+        Ok(full_path)
+    }
+
+    /// Get the configuration
+    pub fn config(&self) -> &DiskManagerConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn create_test_disk_config(temp_dir: &TempDir, disk_id: &str) -> DiskConfig {
+        let path = temp_dir.path().join(disk_id);
+        fs::create_dir_all(&path).unwrap();
+        DiskConfig::new(disk_id.to_string(), path, 1024)
+    }
+
+    #[test]
+    fn test_disk_config_creation() {
+        let config = DiskConfig::new("disk1".to_string(), "/test/path", 1024);
+        assert_eq!(config.disk_id, "disk1");
+        assert_eq!(config.path, PathBuf::from("/test/path"));
+        assert_eq!(config.min_free_space, 1024);
+    }
+
+    #[test]
+    fn test_disk_manager_config_validation() {
+        // Valid configuration
+        let temp_dir = TempDir::new().unwrap();
+        let disk1 = create_test_disk_config(&temp_dir, "disk1");
+        let disk2 = create_test_disk_config(&temp_dir, "disk2");
+        let config = DiskManagerConfig::new(vec![disk1, disk2]);
+        assert!(config.validate().is_ok());
+
+        // Empty configuration should fail
+        let empty_config = DiskManagerConfig::new(vec![]);
+        assert!(empty_config.validate().is_err());
+
+        // Duplicate disk IDs should fail
+        let disk1 = create_test_disk_config(&temp_dir, "disk1");
+        let disk1_dup = create_test_disk_config(&temp_dir, "disk1");
+        let dup_config = DiskManagerConfig::new(vec![disk1, disk1_dup]);
+        assert!(dup_config.validate().is_err());
+    }
+
+    #[test]
+    fn test_disk_info_operations() {
+        let temp_dir = TempDir::new().unwrap();
+        let disk_config = create_test_disk_config(&temp_dir, "test_disk");
+        let mut disk_info = DiskInfo::from_config(&disk_config);
+
+        // Initial state
+        assert!(!disk_info.is_online);
+        assert_eq!(disk_info.consecutive_failures, 0);
+
+        // Mark as failed
+        disk_info.mark_failed("Test error".to_string());
+        assert_eq!(disk_info.consecutive_failures, 1);
+        assert_eq!(disk_info.last_error, Some("Test error".to_string()));
+
+        // Mark as online
+        disk_info.mark_online();
+        assert!(disk_info.is_online);
+        assert_eq!(disk_info.consecutive_failures, 0);
+        assert_eq!(disk_info.last_error, None);
+
+        // Test space information
+        disk_info.update_space_info(1000, 200);
+        assert_eq!(disk_info.total_space, 1000);
+        assert_eq!(disk_info.available_space, 200);
+        assert_eq!(disk_info.used_space, 800);
+        assert_eq!(disk_info.usage_percentage(), 80.0);
+    }
+
+    #[test]
+    fn test_disk_manager_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let disk1 = create_test_disk_config(&temp_dir, "disk1");
+        let disk2 = create_test_disk_config(&temp_dir, "disk2");
+        let config = DiskManagerConfig::new(vec![disk1, disk2]);
+
+        let manager = DiskManager::new(config).unwrap();
+        assert_eq!(manager.disks.len(), 2);
+        assert!(manager.disks.contains_key("disk1"));
+        assert!(manager.disks.contains_key("disk2"));
+    }
+
+    #[test]
+    fn test_disk_manager_available_disks() {
+        let temp_dir = TempDir::new().unwrap();
+        let disk1 = create_test_disk_config(&temp_dir, "disk1");
+        let config = DiskManagerConfig::new(vec![disk1]);
+
+        let manager = DiskManager::new(config).unwrap();
+
+        // Should have available disks after initialization
+        assert!(manager.has_available_disks());
+        let available = manager.get_available_disks();
+        assert!(!available.is_empty());
+
+        let available_ids = manager.get_available_disk_ids();
+        assert!(available_ids.contains(&"disk1".to_string()));
+    }
+
+    #[test]
+    fn test_disk_stats() {
+        let temp_dir = TempDir::new().unwrap();
+        let disk1 = create_test_disk_config(&temp_dir, "disk1");
+        let disk2 = create_test_disk_config(&temp_dir, "disk2");
+        let config = DiskManagerConfig::new(vec![disk1, disk2]);
+
+        let manager = DiskManager::new(config).unwrap();
+        let stats = manager.get_stats();
+
+        assert_eq!(stats.total_disks, 2);
+        assert!(stats.online_disks > 0);
+        assert!(stats.total_space > 0);
+    }
+
+    #[test]
+    fn test_ensure_disk_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let disk1 = create_test_disk_config(&temp_dir, "disk1");
+        let config = DiskManagerConfig::new(vec![disk1]);
+
+        let manager = DiskManager::new(config).unwrap();
+
+        let subpath = Path::new("test/subdirectory");
+        let full_path = manager.ensure_disk_directory("disk1", subpath).unwrap();
+
+        assert!(full_path.exists());
+        assert!(full_path.is_dir());
+    }
+
+    #[test]
+    fn test_disk_not_found_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let disk1 = create_test_disk_config(&temp_dir, "disk1");
+        let config = DiskManagerConfig::new(vec![disk1]);
+
+        let manager = DiskManager::new(config).unwrap();
+
+        let result = manager.ensure_disk_directory("nonexistent_disk", Path::new("test"));
+        assert!(matches!(result, Err(DiskManagerError::DiskNotFound { .. })));
+    }
+
+    #[test]
+    fn test_monitoring_config_defaults() {
+        let config = DiskMonitoringConfig::default();
+        assert_eq!(config.check_interval_seconds, 30);
+        assert_eq!(config.failure_threshold_consecutive, 3);
+        assert_eq!(config.space_alert_threshold_percent, 90);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 //! erasure coding, and distributed storage operations.
 
 pub mod chunk_format;
+pub mod chunk_placement;
+pub mod disk_manager;
 pub mod erasure_coding;
 pub mod integrity_checker;
 pub mod metadata_store;
@@ -11,6 +13,8 @@ pub mod storage_layout;
 pub mod storage_node;
 
 pub use chunk_format::*;
+pub use chunk_placement::*;
+pub use disk_manager::*;
 pub use erasure_coding::*;
 pub use integrity_checker::*;
 pub use metadata_store::*;


### PR DESCRIPTION
#### **Phase 1C: Multi-Disk Support (1-2 weeks)** 
**Goal:** Add support for multiple storage devices per node

**Deliverables:**
- Extend storage layout with:
  - Multi-disk configuration and detection
  - Chunk placement across disks (max 1 chunk per stripe per disk)
  - Disk space monitoring and balancing
  - Disk failure handling (mark disk offline, continue operations)

**Success Criteria:**
- Can utilize multiple disks for chunk storage
- Proper blast radius protection (no stripe has >1 chunk per disk)
- Balances storage across available disks by free space
- Gracefully handles individual disk failures
- No clippy errors or warnings
- No rust format errors or warnings.

**Key Files:** `src/disk_manager.rs`, `src/chunk_placement.rs`