### PR TITLE
Phase 2A.3: Ping/Heartbeat Protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-ping",
  "libp2p-quic",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -2149,6 +2150,7 @@ dependencies = [
  "libp2p-gossipsub",
  "libp2p-identity",
  "libp2p-kad",
+ "libp2p-ping",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client",
@@ -2176,6 +2178,22 @@ dependencies = [
  "tracing",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74bb7fcdfd9fead4144a3859da0b49576f171a8c8c7c0bfc7c541921d25e60d3"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.5",
+ "tracing",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 
 # Networking
-libp2p = { version = "0.56", features = ["tcp", "noise", "yamux", "gossipsub", "mdns", "kad", "macros", "tokio"] }
+libp2p = { version = "0.56", features = ["tcp", "noise", "yamux", "gossipsub", "mdns", "kad", "ping", "macros", "tokio"] }
 tonic = "0.10"
 tonic-build = "0.10"
 prost = "0.12"

--- a/docs/phase_2a_detailed.md
+++ b/docs/phase_2a_detailed.md
@@ -106,7 +106,7 @@ By breaking this into smaller phases, we achieve:
 
 ---
 
-### **Phase 2A.3: Ping/Heartbeat Protocol (2-3 days)**
+### **Phase 2A.3: Ping/Heartbeat Protocol (2-3 days)** COMPLETED
 **Goal:** Add basic liveness detection using libp2p's ping behavior
 
 **Context:** Integrate the first libp2p behavior to enable heartbeat monitoring. This provides the foundation for failure detection.

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -13,6 +13,7 @@ pub async fn create_test_node(port: u16) -> Result<(NetworkService, NetworkServi
     let config = NetworkConfig {
         listen_address: format!("/ip4/127.0.0.1/tcp/{}", port),
         initial_peers: Vec::new(),
+        ping: wormfs::networking::PingConfig::default(),
     };
 
     let (mut service, handle) = NetworkService::new(config.clone())?;


### PR DESCRIPTION
### **Phase 2A.3: Ping/Heartbeat Protocol (2-3 days)** 

**Goal:** Add basic liveness detection using libp2p's ping behavior

**Context:** Integrate the first libp2p behavior to enable heartbeat monitoring. This provides the foundation for failure detection.

**Deliverables:**
- Add ping::Behaviour to NetworkBehaviour
- Track ping RTT for connected peers
- Emit events for ping success/failure
- Update heartbeat tracking on successful pings
- Add configuration for ping interval and timeout
- Log ping statistics for debugging

**Success Criteria:**
- Ping behavior integrated into swarm without conflicts
- Can measure RTT between connected peers
- Ping failures are detected and logged appropriately
- Ping success resets failure counters
- Integration test verifies ping works between nodes
- Configuration controls ping behavior
- No clippy errors or warnings
- No cargo formatting errors or warnings

**Test Strategy:**
- Integration test: Connect two nodes, verify regular ping events
- Integration test: Measure RTT, verify reasonable values
- Integration test: Simulate network delay, measure RTT impact
- Integration test: Disconnect a node, verify ping failures detected
- Unit test: Ping configuration parsing
- Performance test: Ping overhead measurement

**Files Modified:**
- `src/networking.rs` - Integrate ping behavior
- `src/networking.rs` - Add ping event handling
- `config/storage_node.yaml` - Add ping configuration
- `tests/integration_tests.rs` - Ping functionality tests
