### PR TITLE
Phase 2A.4: Peer State Tracking

### DIFF
--- a/docs/phase_2a_detailed.md
+++ b/docs/phase_2a_detailed.md
@@ -145,7 +145,7 @@ By breaking this into smaller phases, we achieve:
 
 ---
 
-### **Phase 2A.4: Peer State Tracking (2-3 days)**
+### **Phase 2A.4: Peer State Tracking (2-3 days)** COMPLETED
 **Goal:** Implement basic peer state management
 
 **Context:** Create a systematic way to track peer states and transitions. This provides the foundation for higher-level networking logic.


### PR DESCRIPTION
### **Phase 2A.4: Peer State Tracking (2-3 days)** 

**Goal:** Implement basic peer state management

**Context:** Create a systematic way to track peer states and transitions. This provides the foundation for higher-level networking logic.

**Deliverables:**
- `PeerInfo` structure for tracking peer state (Connected, Disconnected, Failed)
- HashMap to store peer states by PeerId
- Update peer state on connection/disconnection events
- Update peer state on ping success/failure
- Simple API to query peer states
- State transition logging for debugging

**Success Criteria:**
- Can track Connected/Disconnected/Failed states
- State updates happen consistently in response to swarm events
- Can query current state of any known peer
- State transitions are logged for debugging
- Unit tests for all state transitions
- Thread-safe access to peer state
- No clippy errors or warnings
- No cargo formatting errors or warnings

**Test Strategy:**
- Unit test: State transitions for all event types
- Integration test: Connect/disconnect nodes, verify state changes
- Integration test: Check peer states via query API
- Integration test: Verify state consistency across multiple events
- Integration test: Concurrent state updates handled correctly
- Error test: Invalid peer state transitions rejected

**Files Modified:**
- `src/networking.rs` - Add peer state tracking
- `src/peer_manager.rs` - Enhance with state management
- `tests/unit_tests.rs` - Peer state unit tests
- `tests/integration_tests.rs` - Peer state integration tests
