### PR TITLE
Phase 2A.7: Unresponsive Peer Detection

### DIFF
--- a/docs/phase_2a_detailed.md
+++ b/docs/phase_2a_detailed.md
@@ -264,7 +264,7 @@ By breaking this into smaller phases, we achieve:
 
 ---
 
-### **Phase 2A.7: Unresponsive Peer Detection (2-3 days)**
+### **Phase 2A.7: Unresponsive Peer Detection (2-3 days)** COMPLETED
 **Goal:** Detect and mark peers that stop responding to pings
 
 **Context:** Implement failure detection that can distinguish between network issues and peer failures. This is critical for distributed system reliability.


### PR DESCRIPTION
### **Phase 2A.7: Unresponsive Peer Detection (2-3 days)** 

**Goal:** Detect and mark peers that stop responding to pings

**Context:** Implement failure detection that can distinguish between network issues and peer failures. This is critical for distributed system reliability.

**Deliverables:**
- Track consecutive ping failures per peer
- Configurable threshold for marking unresponsive
- Emit PeerUnresponsive events
- Timeout-based detection (no ping response in N seconds)
- Update peer state to Failed on detection
- Distinguish between temporary and permanent failures

**Success Criteria:**
- Unresponsive peers detected within configured timeout
- Consecutive failures tracked correctly per peer
- PeerUnresponsive events emitted with proper context
- Timeout is configurable and respected
- Integration test with simulated failure scenarios
- False positives minimized (network delay vs failure)
- No clippy errors or warnings
- No cargo formatting errors or warnings

**Test Strategy:**
- Integration test: Connect two nodes, pause one, verify detection
- Integration test: Verify other node detects unresponsiveness
- Integration test: Check timeout is within configured bounds
- Integration test: Resume node, verify recovery detection
- Performance test: Tune timeout for optimal failure detection
- Stress test: Multiple simultaneous failures

**Files Modified:**
- `src/networking.rs` - Add unresponsive peer detection
- `src/peer_manager.rs` - Enhance with failure detection
- `config/storage_node.yaml` - Add timeout configuration
- `tests/integration_tests.rs` - Failure detection tests
