### PR TITLE
Phase 2B.1: Protocol Definition & Codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot 0.12.4",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1843,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2 0.5.10",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,12 +1965,14 @@ dependencies = [
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
  "libp2p-core",
+ "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
@@ -1998,6 +2032,22 @@ dependencies = [
  "unsigned-varint 0.8.0",
  "void",
  "web-time",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.41.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17cbcf7160ff35c3e8e560de4a068fe9d6cb777ea72840e48eb76ff9576c4b6"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hickory-resolver",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot 0.12.4",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -2142,6 +2192,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-request-response"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c314fe28368da5e3a262553fb0ad575c1c8934c461e10de10265551478163836"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.5",
+ "smallvec",
+ "tracing",
+ "void",
+]
+
+[[package]]
 name = "libp2p-swarm"
 version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2325,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -3219,6 +3298,12 @@ checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 
 [[package]]
 name = "ring"
@@ -4392,6 +4477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4748,6 +4839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.9"
 humantime-serde = "1.1"
 
 # Networking
-libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "mdns", "kad"] }
+libp2p = { version = "0.53", features = ["tcp", "noise", "yamux", "gossipsub", "mdns", "kad", "request-response", "dns"] }
 tonic = "0.10"
 tonic-build = "0.10"
 prost = "0.12"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+// Build script for WormFS
+//
+// This script generates Rust code from protobuf definitions
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Compile protobuf files
+    tonic_build::configure()
+        .build_server(false) // We don't need gRPC server code yet (Phase 3A)
+        .build_client(false) // We don't need gRPC client code yet (Phase 3A)
+        .compile(&["proto/wormfs.proto"], &["proto"])?;
+
+    // Tell cargo to rerun this build script if the proto file changes
+    println!("cargo:rerun-if-changed=proto/wormfs.proto");
+
+    Ok(())
+}

--- a/config/storage_node.yaml
+++ b/config/storage_node.yaml
@@ -1,11 +1,64 @@
 # WormFS Storage Node Configuration
 # This file contains the configuration settings for a WormFS storage node
 
-# Unique identifier for this storage node
+# Unique identifier for this storage node (UUID)
 node_id: "550e8400-e29b-41d4-a716-446655440000"
 
 # Path to the SQLite metadata database
 metadata_db_path: "data/metadata.db"
+
+# Raft consensus configuration
+raft:
+  # Numeric node ID for Raft (must be unique across cluster)
+  node_id: 1
+  # Heartbeat interval (how often leader sends heartbeats)
+  heartbeat_interval: 250ms
+  # Minimum election timeout
+  election_timeout_min: 1000ms
+  # Maximum election timeout
+  election_timeout_max: 2000ms
+  # Snapshot interval (hours)
+  snapshot_interval_hours: 24
+  # Snapshot log size threshold (MB)
+  snapshot_log_size_mb: 10
+  # Use lease-based reads for performance
+  use_lease_reads: true
+  # Lease duration for read optimization
+  lease_duration: 5s
+  # Path to Raft log storage
+  log_path: "data/raft_log"
+  # Path to state machine (metadata) storage
+  state_path: "data/metadata"
+
+# Network configuration for Raft cluster communication
+network:
+  # Listen address for this node (libp2p multiaddr format)
+  listen_address: "/ip4/0.0.0.0/tcp/3000"
+  # Request timeout in milliseconds
+  request_timeout_ms: 5000
+  # Connection timeout in milliseconds
+  connection_timeout_ms: 10000
+  # Maximum connection retry attempts
+  max_retries: 3
+  # Peer health check timeout
+  health_timeout_ms: 10000
+  # Maximum failures before marking peer as failed
+  max_peer_failures: 3
+  
+  # Static peer configuration (other nodes in the Raft cluster)
+  # For a 3-node cluster, list the other 2 nodes here
+  peers:
+    - node_id: 2
+      address: "/ip4/127.0.0.1/tcp/3001"
+    - node_id: 3
+      address: "/ip4/127.0.0.1/tcp/3002"
+  
+  # Example for production multi-host cluster:
+  # peers:
+  #   - node_id: 2
+  #     address: "/ip4/192.168.1.101/tcp/3000"
+  #   - node_id: 3
+  #     address: "/ip4/192.168.1.102/tcp/3000"
 
 # Storage configuration
 storage_config:

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -255,18 +255,13 @@ raft:
   - Message routing and handling
   - Leader discovery and client routing
   - Cluster membership management
-- Network transport implementation (choose one):
-  - **Option A:** `raft/libp2p_network.rs` - Full libp2p implementation:
+- Network transport implementation:
+  - `raft/libp2p_network.rs` - Full libp2p implementation:
     - Custom RaftNetwork trait implementation over libp2p
     - Request-response protocol for Raft RPCs
     - Peer discovery and connection management
     - Transport encryption using noise protocol
     - Connection pooling and automatic reconnection
-  - **Option B:** `raft/tcp_network.rs` - Simpler TCP-based implementation:
-    - Direct TCP connections for Raft RPCs
-    - Serialization using serde/bincode
-    - Basic peer management
-    - TLS for encryption
 - `raft/peer_manager.rs` for health monitoring and failover
 - Integration tests with actual network transport (`tests/raft_integration_tests.rs`):
   - 3-node cluster formation

--- a/docs/phase_2b_detailed_plan.md
+++ b/docs/phase_2b_detailed_plan.md
@@ -1,0 +1,514 @@
+# Phase 2B: Detailed Implementation Plan for libp2p Transport
+
+## Overview
+
+This document outlines the incremental implementation strategy for Phase 2B: Network Transport & Cluster Testing. The implementation is broken down into manageable chunks that can be implemented and tested independently.
+
+## Architecture Overview
+
+### Component Structure
+
+```
+src/transport/
+├── mod.rs                    # Existing: Error types, PeerInfo, exports
+├── libp2p_network.rs         # To expand: Main network implementation
+├── peer_manager.rs           # Existing: Health monitoring
+├── protocol.rs               # NEW: Raft RPC protocol definitions
+└── codec.rs                  # NEW: Message serialization/deserialization
+```
+
+### Key Design Decisions
+
+1. **Protocol Layer:** Use libp2p request-response protocol for Raft RPCs
+2. **Serialization:** Protobuf for all message serialization
+3. **Codec Separation:** Separate codec layer for clean serialization
+4. **Architecture:** Event-driven with tokio channels
+5. **Separation of Concerns:** Clear boundary between transport and Raft logic
+
+## Implementation Chunks
+
+### Chunk 1: Protocol Definition & Codec (~150 lines)
+
+**Files:** 
+- `src/transport/protocol.rs` (NEW)
+- `src/transport/codec.rs` (NEW)
+
+**Purpose:** Define the Raft RPC protocol for libp2p request-response and handle message serialization
+
+**What to implement:**
+
+#### protocol.rs
+- Define `RaftProtocol` codec for request-response
+- Implement `ProtocolName` trait
+- Request/Response message types
+- Protocol behavior configuration
+
+```rust
+pub struct RaftProtocol;
+
+impl ProtocolName for RaftProtocol {
+    fn protocol_name(&self) -> &[u8] {
+        b"/wormfs/raft/1.0.0"
+    }
+}
+
+pub struct RaftCodec;
+
+impl RequestResponseCodec for RaftCodec {
+    type Protocol = RaftProtocol;
+    type Request = RaftRequest;   // From protobuf
+    type Response = RaftResponse; // From protobuf
+    
+    async fn read_request<T>(...) -> io::Result<Self::Request>;
+    async fn read_response<T>(...) -> io::Result<Self::Response>;
+    async fn write_request<T>(...) -> io::Result<()>;
+    async fn write_response<T>(...) -> io::Result<()>;
+}
+```
+
+#### codec.rs
+- Encode/decode functions for Raft messages
+- Error handling for malformed messages
+- Integration with prost
+
+```rust
+pub fn encode_raft_request(req: &RaftRequest) -> Result<Vec<u8>>;
+pub fn decode_raft_request(bytes: &[u8]) -> Result<RaftRequest>;
+pub fn encode_raft_response(resp: &RaftResponse) -> Result<Vec<u8>>;
+pub fn decode_raft_response(bytes: &[u8]) -> Result<RaftResponse>;
+```
+
+**Why this first:** Establishes the communication contract before implementing networking
+
+**Estimated Time:** 1-2 hours
+
+---
+
+### Chunk 2: Libp2p Swarm Setup (~200 lines)
+
+**File:** `src/transport/libp2p_network.rs` (expand existing)
+
+**Purpose:** Initialize libp2p Swarm with proper configuration
+
+**What to implement:**
+
+```rust
+use libp2p::{
+    core::upgrade,
+    noise,
+    tcp,
+    yamux,
+    swarm::{Swarm, SwarmBuilder},
+    request_response::{RequestResponse, RequestResponseConfig},
+};
+
+pub struct Libp2pNetwork {
+    swarm: Swarm<RaftBehaviour>,
+    local_peer_id: PeerId,
+    config: NetworkConfig,
+    peer_manager: PeerManager,
+    // Event channels for async communication
+    event_tx: mpsc::Sender<NetworkEvent>,
+    event_rx: mpsc::Receiver<NetworkEvent>,
+}
+
+// NetworkBehaviour for Raft
+#[derive(NetworkBehaviour)]
+struct RaftBehaviour {
+    request_response: RequestResponse<RaftCodec>,
+}
+
+impl Libp2pNetwork {
+    pub fn new(config: NetworkConfig) -> Result<Self> {
+        // 1. Set up TCP transport
+        // 2. Add noise authentication
+        // 3. Add yamux multiplexing
+        // 4. Configure request-response behavior
+        // 5. Build and return Swarm
+    }
+}
+```
+
+**Components:**
+- TCP transport setup
+- Noise authentication for encryption
+- Yamux multiplexing
+- Request-response behavior for Raft RPCs
+- Swarm initialization
+- Event channel creation
+
+**Why this second:** Core infrastructure needed before connections
+
+**Estimated Time:** 2-3 hours
+
+---
+
+### Chunk 3: Connection Management (~200 lines)
+
+**File:** `src/transport/libp2p_network.rs` (expand)
+
+**Purpose:** Handle peer connections and lifecycle
+
+**What to implement:**
+
+```rust
+impl Libp2pNetwork {
+    /// Connect to all configured static peers
+    pub async fn dial_peers(&mut self) -> Result<()> {
+        for peer in &self.config.peers {
+            let multiaddr = peer.address.parse()?;
+            self.swarm.dial(multiaddr)?;
+            tracing::info!("Dialing peer {} at {}", peer.node_id, peer.address);
+        }
+        Ok(())
+    }
+    
+    /// Handle new connection established
+    fn handle_connection_established(&mut self, peer_id: PeerId) {
+        // Update peer manager
+        // Log connection
+        // Emit event
+    }
+    
+    /// Handle connection closed
+    fn handle_connection_closed(&mut self, peer_id: PeerId, cause: &ConnectionError) {
+        // Update peer manager
+        // Schedule reconnection if needed
+        // Emit event
+    }
+    
+    /// Automatic reconnection logic
+    async fn reconnect_failed_peers(&mut self) {
+        // Check peer manager for failed peers
+        // Retry connection with backoff
+    }
+}
+```
+
+**Integration Points:**
+- PeerManager for health tracking
+- Automatic reconnection with exponential backoff
+- Connection event handling
+- Peer ID to NodeID mapping
+
+**Why this third:** Enables actual peer-to-peer communication
+
+**Estimated Time:** 2-3 hours
+
+---
+
+### Chunk 4: Message Sending (~150 lines)
+
+**File:** `src/transport/libp2p_network.rs` (expand)
+
+**Purpose:** Implement outbound Raft RPC sending
+
+**What to implement:**
+
+```rust
+impl Libp2pNetwork {
+    /// Send AppendEntries RPC to target node
+    pub async fn send_append_entries(
+        &mut self,
+        target: NodeId,
+        request: AppendEntriesRequest,
+    ) -> Result<AppendEntriesResponse> {
+        let peer_id = self.node_id_to_peer_id(target)?;
+        let raft_request = RaftRequest::AppendEntries(request);
+        let response = self.send_request(peer_id, raft_request).await?;
+        match response {
+            RaftResponse::AppendEntries(resp) => Ok(resp),
+            _ => Err(TransportError::Network("Unexpected response type".into())),
+        }
+    }
+    
+    /// Send Vote RPC to target node
+    pub async fn send_vote(
+        &mut self,
+        target: NodeId,
+        request: VoteRequest,
+    ) -> Result<VoteResponse>;
+    
+    /// Send InstallSnapshot RPC to target node
+    pub async fn send_install_snapshot(
+        &mut self,
+        target: NodeId,
+        request: InstallSnapshotRequest,
+    ) -> Result<InstallSnapshotResponse>;
+    
+    /// Generic request sender with timeout
+    async fn send_request(
+        &mut self,
+        peer_id: PeerId,
+        request: RaftRequest,
+    ) -> Result<RaftResponse> {
+        // Use request-response behavior
+        // Apply timeout
+        // Handle errors
+        // Update peer manager on success/failure
+    }
+    
+    /// Map NodeID to PeerID
+    fn node_id_to_peer_id(&self, node_id: NodeId) -> Result<PeerId>;
+}
+```
+
+**Features:**
+- Type-safe RPC methods for each Raft message type
+- Timeout handling per config
+- Automatic peer health updates
+- Error handling and retry logic
+
+**Why this fourth:** Core Raft RPC functionality
+
+**Estimated Time:** 1-2 hours
+
+---
+
+### Chunk 5: Message Receiving & Event Loop (~200 lines)
+
+**File:** `src/transport/libp2p_network.rs` (expand)
+
+**Purpose:** Handle incoming messages and drive the event loop
+
+**What to implement:**
+
+```rust
+/// Incoming message handler
+pub type IncomingRequestHandler = Box<dyn Fn(RaftRequest) -> RaftResponse + Send>;
+
+impl Libp2pNetwork {
+    /// Main event loop
+    pub async fn run(mut self) -> Result<()> {
+        loop {
+            tokio::select! {
+                // Handle swarm events
+                event = self.swarm.select_next_some() => {
+                    self.handle_swarm_event(event).await?;
+                }
+                
+                // Handle external commands
+                cmd = self.event_rx.recv() => {
+                    if let Some(cmd) = cmd {
+                        self.handle_command(cmd).await?;
+                    }
+                }
+                
+                // Periodic maintenance
+                _ = tokio::time::sleep(Duration::from_secs(1)) => {
+                    self.maintenance().await?;
+                }
+            }
+        }
+    }
+    
+    /// Handle incoming requests
+    async fn handle_swarm_event(&mut self, event: SwarmEvent) -> Result<()> {
+        match event {
+            SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(event)) => {
+                match event {
+                    RequestResponseEvent::Message { peer, message } => {
+                        self.handle_incoming_message(peer, message).await?;
+                    }
+                    RequestResponseEvent::OutboundFailure { peer, error, .. } => {
+                        self.peer_manager.record_failure(peer);
+                    }
+                    RequestResponseEvent::InboundFailure { peer, error } => {
+                        tracing::warn!("Inbound failure from {}: {:?}", peer, error);
+                    }
+                    _ => {}
+                }
+            }
+            SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                self.handle_connection_established(peer_id);
+            }
+            SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+                self.handle_connection_closed(peer_id, &cause);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    
+    /// Handle incoming Raft RPC
+    async fn handle_incoming_message(
+        &mut self,
+        peer: PeerId,
+        message: RequestResponseMessage<RaftRequest, RaftResponse>,
+    ) -> Result<()> {
+        match message {
+            RequestResponseMessage::Request { request, channel, .. } => {
+                // Call registered handler
+                let response = (self.request_handler)(request);
+                // Send response back
+                self.swarm.behaviour_mut().request_response.send_response(channel, response)?;
+            }
+            RequestResponseMessage::Response { response, .. } => {
+                // Handle response (already handled in send_request)
+            }
+        }
+        Ok(())
+    }
+    
+    /// Register handler for incoming requests
+    pub fn set_request_handler(&mut self, handler: IncomingRequestHandler) {
+        self.request_handler = handler;
+    }
+    
+    /// Periodic maintenance tasks
+    async fn maintenance(&mut self) -> Result<()> {
+        // Reconnect to failed peers
+        self.reconnect_failed_peers().await?;
+        // Clean up old state
+        Ok(())
+    }
+}
+```
+
+**Features:**
+- Tokio-based async event loop
+- Incoming request handling with callbacks
+- Automatic reconnection on failures
+- Health monitoring updates
+- Command channel for external control
+
+**Why this fifth:** Completes bidirectional communication
+
+**Estimated Time:** 2-3 hours
+
+---
+
+### Chunk 6: Integration & Testing (~100 lines)
+
+**File:** `tests/transport_tests.rs` (NEW)
+
+**Purpose:** Test transport layer independently
+
+**What to implement:**
+
+```rust
+#[tokio::test]
+async fn test_two_node_connection() {
+    // Create two nodes with configs pointing to each other
+    let node1 = Libp2pNetwork::new(config1).unwrap();
+    let node2 = Libp2pNetwork::new(config2).unwrap();
+    
+    // Start both nodes
+    tokio::spawn(async move { node1.run().await });
+    tokio::spawn(async move { node2.run().await });
+    
+    // Wait for connection
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    
+    // Verify connection established
+    // Check peer manager shows connected
+}
+
+#[tokio::test]
+async fn test_message_send_receive() {
+    // Set up two connected nodes
+    // Send a test message from node1 to node2
+    // Verify node2 receives it
+    // Verify response comes back
+}
+
+#[tokio::test]
+async fn test_connection_failure_recovery() {
+    // Set up two nodes
+    // Simulate connection failure
+    // Verify automatic reconnection
+    // Verify peer manager updates correctly
+}
+
+#[tokio::test]
+async fn test_multiple_peers() {
+    // Set up 3-node cluster
+    // Verify all nodes connect to each other
+    // Test message passing between all pairs
+}
+```
+
+**Test Coverage:**
+- 2-node connection establishment
+- Message send/receive roundtrip
+- Connection failure and recovery
+- Multi-node peer discovery
+- Timeout handling
+- Error scenarios
+
+**Why this last:** Validates all components work together
+
+**Estimated Time:** 1-2 hours
+
+---
+
+## Implementation Timeline
+
+### Estimated Time Per Chunk
+
+1. **Chunk 1** (Protocol & Codec): 1-2 hours
+2. **Chunk 2** (Swarm Setup): 2-3 hours
+3. **Chunk 3** (Connections): 2-3 hours
+4. **Chunk 4** (Send Messages): 1-2 hours
+5. **Chunk 5** (Receive & Event Loop): 2-3 hours
+6. **Chunk 6** (Testing): 1-2 hours
+
+**Total:** 9-15 hours of implementation work
+
+### Suggested Order
+
+Implement in sequence 1→2→3→4→5→6, as each builds on the previous.
+
+## After Transport Layer Completion
+
+Once the transport layer is complete and tested, the next major components are:
+
+### Raft Node Manager (`src/raft/node.rs`)
+- Create Raft instance with storage components
+- Implement RaftNetwork trait over libp2p transport
+- Message routing for Raft operations
+- Leader discovery and client routing
+- Estimated: 400-600 lines, 4-6 hours
+
+### 3-Node Cluster Integration Tests
+- Full cluster setup with real networking
+- Leader election validation (< 2s requirement)
+- Log replication verification
+- Network partition scenarios
+- Failover testing
+- Estimated: 200-300 lines, 3-4 hours
+
+### Docker Compose Configuration
+- Multi-node cluster setup
+- Network configuration
+- Volume management
+- Environment variables
+- Estimated: 1-2 hours
+
+## Success Criteria
+
+The libp2p transport implementation will be considered complete when:
+
+1. ✅ Two nodes can connect to each other via libp2p
+2. ✅ Nodes can send and receive Raft RPCs (AppendEntries, Vote, InstallSnapshot)
+3. ✅ Connection failures are detected and automatic reconnection works
+4. ✅ All transport tests pass
+5. ✅ No memory leaks or connection leaks
+6. ✅ Peer health monitoring correctly tracks connection status
+7. ✅ Ready for integration with Raft node manager
+
+## References
+
+- [libp2p request-response documentation](https://docs.rs/libp2p-request-response/)
+- [OpenRaft networking examples](https://github.com/databendlabs/openraft/tree/release-0.9/examples)
+- WormFS protobuf definitions: `proto/wormfs.proto`
+- Existing peer manager: `src/transport/peer_manager.rs`
+
+## Notes
+
+- All network code should be thoroughly async
+- Use tracing for logging, not println
+- Follow WormFS coding standards (clippy, rustfmt)
+- Test coverage target: >90%
+- Consider backpressure and flow control
+- Handle edge cases: partial sends, connection drops, timeouts

--- a/proto/wormfs.proto
+++ b/proto/wormfs.proto
@@ -1,25 +1,267 @@
 syntax = "proto3";
 package wormfs;
 
-// Placeholder for future WormFS gRPC API
-// This will be expanded in Phase 3A: gRPC API Foundation
-// 
-// Planned services based on implementation.md:
-// - Client-storage communication protocol
-// - Chunk read/write operations
-// - File metadata operations
-// - Health check endpoints
+// ============================================================================
+// Core Metadata Types
+// ============================================================================
+
+message FileMetadata {
+  bytes file_id = 1;        // UUID as 16 bytes
+  uint64 size = 2;
+  uint32 permissions = 3;
+  uint32 uid = 4;
+  uint32 gid = 5;
+  int64 created_at = 6;
+  int64 modified_at = 7;
+  int64 accessed_at = 8;
+  uint64 stripe_size = 9;
+  uint32 data_shards = 10;
+  uint32 parity_shards = 11;
+}
+
+enum LockType {
+  LOCK_TYPE_UNSPECIFIED = 0;
+  LOCK_TYPE_READ = 1;
+  LOCK_TYPE_WRITE = 2;
+}
+
+// ============================================================================
+// Metadata Operations (Raft Log Entries)
+// ============================================================================
+
+message MetadataOp {
+  oneof operation {
+    CreateFile create_file = 1;
+    UpdateFile update_file = 2;
+    DeleteFile delete_file = 3;
+    RegisterChunk register_chunk = 4;
+    UpdateChunkLocation update_chunk_location = 5;
+    RemoveChunk remove_chunk = 6;
+    AcquireLock acquire_lock = 7;
+    ReleaseLock release_lock = 8;
+    ExtendLock extend_lock = 9;
+    AddNode add_node = 10;
+    RemoveNode remove_node = 11;
+  }
+  
+  message CreateFile {
+    FileMetadata metadata = 1;
+  }
+  
+  message UpdateFile {
+    bytes file_id = 1;
+    FileMetadata metadata = 2;
+  }
+  
+  message DeleteFile {
+    bytes file_id = 1;
+  }
+  
+  message RegisterChunk {
+    bytes chunk_id = 1;
+    uint64 node_id = 2;
+    bytes stripe_id = 3;
+    bytes file_id = 4;
+  }
+  
+  message UpdateChunkLocation {
+    bytes chunk_id = 1;
+    uint64 new_node_id = 2;
+  }
+  
+  message RemoveChunk {
+    bytes chunk_id = 1;
+  }
+  
+  message AcquireLock {
+    bytes file_id = 1;
+    LockType lock_type = 2;
+    string client_id = 3;
+  }
+  
+  message ReleaseLock {
+    bytes file_id = 1;
+    string client_id = 2;
+  }
+  
+  message ExtendLock {
+    bytes file_id = 1;
+    string client_id = 2;
+  }
+  
+  message AddNode {
+    uint64 node_id = 1;
+    string address = 2;
+  }
+  
+  message RemoveNode {
+    uint64 node_id = 1;
+  }
+}
+
+message MetadataOpResponse {
+  bool success = 1;
+  string error_message = 2;  // Only set if success = false
+}
+
+// ============================================================================
+// Raft Network Messages
+// ============================================================================
+
+message LogEntry {
+  uint64 index = 1;
+  uint64 term = 2;
+  bytes payload = 3;  // Serialized MetadataOp
+}
+
+message LogId {
+  uint64 leader_id = 1;
+  uint64 index = 2;
+}
+
+message AppendEntriesRequest {
+  uint64 term = 1;
+  uint64 leader_id = 2;
+  uint64 prev_log_index = 3;
+  uint64 prev_log_term = 4;
+  repeated LogEntry entries = 5;
+  uint64 leader_commit = 6;
+}
+
+message AppendEntriesResponse {
+  uint64 term = 1;
+  bool success = 2;
+  oneof conflict {
+    uint64 conflict_index = 3;
+  }
+}
+
+message VoteRequest {
+  uint64 term = 1;
+  uint64 candidate_id = 2;
+  uint64 last_log_index = 3;
+  uint64 last_log_term = 4;
+}
+
+message VoteResponse {
+  uint64 term = 1;
+  bool vote_granted = 2;
+  uint64 last_log_index = 3;
+}
+
+message InstallSnapshotRequest {
+  uint64 term = 1;
+  uint64 leader_id = 2;
+  uint64 last_included_index = 3;
+  uint64 last_included_term = 4;
+  uint64 offset = 5;
+  bytes data = 6;
+  bool done = 7;  // Is this the last chunk?
+}
+
+message InstallSnapshotResponse {
+  uint64 term = 1;
+  bool success = 2;
+}
+
+// ============================================================================
+// Raft Message Wrappers
+// ============================================================================
+
+// Wrapper for all Raft RPC requests
+message RaftRequest {
+  oneof request {
+    AppendEntriesRequest append_entries = 1;
+    VoteRequest vote = 2;
+    InstallSnapshotRequest install_snapshot = 3;
+  }
+}
+
+// Wrapper for all Raft RPC responses
+message RaftResponse {
+  oneof response {
+    AppendEntriesResponse append_entries = 1;
+    VoteResponse vote = 2;
+    InstallSnapshotResponse install_snapshot = 3;
+  }
+}
+
+// ============================================================================
+// Cluster Management
+// ============================================================================
+
+message NodeInfo {
+  uint64 node_id = 1;
+  string address = 2;
+  string peer_id = 3;  // libp2p PeerId
+  bool is_leader = 4;
+  uint64 last_heartbeat = 5;
+  NodeState state = 6;
+}
+
+enum NodeState {
+  NODE_STATE_UNSPECIFIED = 0;
+  NODE_STATE_LEADER = 1;
+  NODE_STATE_FOLLOWER = 2;
+  NODE_STATE_CANDIDATE = 3;
+}
+
+message ClusterStatus {
+  repeated NodeInfo nodes = 1;
+  uint64 current_term = 2;
+  uint64 leader_id = 3;
+  uint64 commit_index = 4;
+  uint64 last_applied = 5;
+}
+
+// ============================================================================
+// Client API Messages (for future use)
+// ============================================================================
+
+message ClientWriteRequest {
+  MetadataOp operation = 1;
+}
+
+message ClientWriteResponse {
+  bool success = 1;
+  string error_message = 2;
+  LogId log_id = 3;  // Log position of the operation
+}
+
+message ClientReadRequest {
+  bytes file_id = 1;
+  ReadMode mode = 2;
+}
+
+enum ReadMode {
+  READ_MODE_UNSPECIFIED = 0;
+  READ_MODE_LINEARIZABLE = 1;
+  READ_MODE_LEASE = 2;
+  READ_MODE_STALE = 3;
+}
+
+message ClientReadResponse {
+  bool success = 1;
+  string error_message = 2;
+  FileMetadata metadata = 3;
+  uint64 last_applied_index = 4;
+  bool is_stale = 5;
+}
+
+// ============================================================================
+// Future WormFS Client-Storage gRPC API (Phase 3A)
+// ============================================================================
 
 service WormFSService {
-  // TODO: Add actual service methods in Phase 3A
-  // Examples of planned methods:
-  // - rpc StoreFile(StoreFileRequest) returns (StoreFileResponse);
-  // - rpc RetrieveFile(RetrieveFileRequest) returns (RetrieveFileResponse);
-  // - rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse);
-  // - rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+  // File operations - to be implemented in Phase 3A
+  // rpc StoreFile(StoreFileRequest) returns (StoreFileResponse);
+  // rpc RetrieveFile(RetrieveFileRequest) returns (RetrieveFileResponse);
+  // rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse);
+  // rpc ListFiles(ListFilesRequest) returns (ListFilesResponse);
+  
+  // Health check
+  // rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
 }
 
-// Placeholder message types
-message Empty {
-  // Placeholder empty message
-}
+// Placeholder for future expansion
+message Empty {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,10 @@ pub mod metadata;
 pub mod node;
 pub mod raft;
 pub mod storage;
+pub mod transport;
 
 // Re-export commonly used types
 pub use metadata::*;
 pub use node::*;
 pub use storage::*;
+pub use transport::*;

--- a/src/raft/mod.rs
+++ b/src/raft/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod config;
 pub mod log_store;
+pub mod proto_types;
 pub mod snapshot_store;
 pub mod state_machine;
 pub mod storage;
@@ -16,6 +17,7 @@ pub mod types;
 
 pub use config::RaftConfig;
 pub use log_store::LogStore;
+pub use proto_types::{deserialize_metadata_op, serialize_metadata_op};
 pub use snapshot_store::SnapshotStore;
 pub use state_machine::StateMachine;
 pub use types::WormFSTypeConfig;

--- a/src/raft/proto_types.rs
+++ b/src/raft/proto_types.rs
@@ -1,0 +1,408 @@
+// Protobuf type wrappers and conversion utilities
+//
+// This module provides conversions between our internal Rust types
+// and the generated protobuf types for serialization.
+
+use crate::raft::types::{
+    FileMetadata as RaftFileMetadata, LockType as RaftLockType, MetadataOp as RaftMetadataOp,
+    MetadataOpResponse as RaftMetadataOpResponse,
+};
+use prost::Message;
+use uuid::Uuid;
+
+// Include the generated protobuf code
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/wormfs.rs"));
+}
+
+use proto::{
+    metadata_op, FileMetadata as ProtoFileMetadata, LockType as ProtoLockType,
+    MetadataOp as ProtoMetadataOp, MetadataOpResponse as ProtoMetadataOpResponse,
+};
+
+// Re-export commonly used proto types
+pub use proto::{
+    ClusterStatus, LogEntry, LogId, NodeInfo, NodeState, RaftRequest as ProtoRaftRequest,
+    RaftResponse as ProtoRaftResponse, ReadMode,
+};
+
+/// Error type for protobuf conversion operations
+#[derive(Debug, thiserror::Error)]
+pub enum ProtoError {
+    #[error("Invalid UUID bytes: expected 16 bytes, got {0}")]
+    InvalidUuid(usize),
+
+    #[error("Protobuf encode error: {0}")]
+    EncodeError(#[from] prost::EncodeError),
+
+    #[error("Protobuf decode error: {0}")]
+    DecodeError(#[from] prost::DecodeError),
+
+    #[error("Missing required field: {0}")]
+    MissingField(String),
+
+    #[error("Invalid enum value: {0}")]
+    InvalidEnum(String),
+}
+
+pub type Result<T> = std::result::Result<T, ProtoError>;
+
+// ============================================================================
+// UUID Conversion Helpers
+// ============================================================================
+
+fn uuid_to_bytes(uuid: Uuid) -> Vec<u8> {
+    uuid.as_bytes().to_vec()
+}
+
+fn bytes_to_uuid(bytes: &[u8]) -> Result<Uuid> {
+    if bytes.len() != 16 {
+        return Err(ProtoError::InvalidUuid(bytes.len()));
+    }
+    let mut array = [0u8; 16];
+    array.copy_from_slice(bytes);
+    Ok(Uuid::from_bytes(array))
+}
+
+// ============================================================================
+// LockType Conversion
+// ============================================================================
+
+impl From<RaftLockType> for ProtoLockType {
+    fn from(lock_type: RaftLockType) -> Self {
+        match lock_type {
+            RaftLockType::Read => ProtoLockType::Read,
+            RaftLockType::Write => ProtoLockType::Write,
+        }
+    }
+}
+
+impl TryFrom<ProtoLockType> for RaftLockType {
+    type Error = ProtoError;
+
+    fn try_from(proto: ProtoLockType) -> Result<Self> {
+        match proto {
+            ProtoLockType::Read => Ok(RaftLockType::Read),
+            ProtoLockType::Write => Ok(RaftLockType::Write),
+            ProtoLockType::Unspecified => {
+                Err(ProtoError::InvalidEnum("Unspecified lock type".to_string()))
+            }
+        }
+    }
+}
+
+impl TryFrom<i32> for RaftLockType {
+    type Error = ProtoError;
+
+    fn try_from(value: i32) -> Result<Self> {
+        ProtoLockType::try_from(value)
+            .map_err(|_| ProtoError::InvalidEnum(format!("lock_type: {}", value)))?
+            .try_into()
+    }
+}
+
+// ============================================================================
+// FileMetadata Conversion
+// ============================================================================
+
+impl From<RaftFileMetadata> for ProtoFileMetadata {
+    fn from(metadata: RaftFileMetadata) -> Self {
+        ProtoFileMetadata {
+            file_id: uuid_to_bytes(metadata.file_id),
+            size: metadata.size,
+            permissions: metadata.permissions,
+            uid: metadata.uid,
+            gid: metadata.gid,
+            created_at: metadata.created_at,
+            modified_at: metadata.modified_at,
+            accessed_at: metadata.accessed_at,
+            stripe_size: metadata.stripe_size,
+            data_shards: metadata.data_shards as u32,
+            parity_shards: metadata.parity_shards as u32,
+        }
+    }
+}
+
+impl TryFrom<ProtoFileMetadata> for RaftFileMetadata {
+    type Error = ProtoError;
+
+    fn try_from(proto: ProtoFileMetadata) -> Result<Self> {
+        Ok(RaftFileMetadata {
+            file_id: bytes_to_uuid(&proto.file_id)?,
+            size: proto.size,
+            permissions: proto.permissions,
+            uid: proto.uid,
+            gid: proto.gid,
+            created_at: proto.created_at,
+            modified_at: proto.modified_at,
+            accessed_at: proto.accessed_at,
+            stripe_size: proto.stripe_size,
+            data_shards: proto.data_shards as u8,
+            parity_shards: proto.parity_shards as u8,
+        })
+    }
+}
+
+// ============================================================================
+// MetadataOp Conversion
+// ============================================================================
+
+impl From<RaftMetadataOp> for ProtoMetadataOp {
+    fn from(op: RaftMetadataOp) -> Self {
+        let operation = match op {
+            RaftMetadataOp::CreateFile { metadata } => {
+                metadata_op::Operation::CreateFile(metadata_op::CreateFile {
+                    metadata: Some(metadata.into()),
+                })
+            }
+            RaftMetadataOp::UpdateFile { file_id, metadata } => {
+                metadata_op::Operation::UpdateFile(metadata_op::UpdateFile {
+                    file_id: uuid_to_bytes(file_id),
+                    metadata: Some(metadata.into()),
+                })
+            }
+            RaftMetadataOp::DeleteFile { file_id } => {
+                metadata_op::Operation::DeleteFile(metadata_op::DeleteFile {
+                    file_id: uuid_to_bytes(file_id),
+                })
+            }
+            RaftMetadataOp::RegisterChunk {
+                chunk_id,
+                node_id,
+                stripe_id,
+                file_id,
+            } => metadata_op::Operation::RegisterChunk(metadata_op::RegisterChunk {
+                chunk_id: uuid_to_bytes(chunk_id),
+                node_id,
+                stripe_id: uuid_to_bytes(stripe_id),
+                file_id: uuid_to_bytes(file_id),
+            }),
+            RaftMetadataOp::UpdateChunkLocation {
+                chunk_id,
+                new_node_id,
+            } => metadata_op::Operation::UpdateChunkLocation(metadata_op::UpdateChunkLocation {
+                chunk_id: uuid_to_bytes(chunk_id),
+                new_node_id,
+            }),
+            RaftMetadataOp::RemoveChunk { chunk_id } => {
+                metadata_op::Operation::RemoveChunk(metadata_op::RemoveChunk {
+                    chunk_id: uuid_to_bytes(chunk_id),
+                })
+            }
+            RaftMetadataOp::AcquireLock {
+                file_id,
+                lock_type,
+                client_id,
+            } => metadata_op::Operation::AcquireLock(metadata_op::AcquireLock {
+                file_id: uuid_to_bytes(file_id),
+                lock_type: ProtoLockType::from(lock_type) as i32,
+                client_id,
+            }),
+            RaftMetadataOp::ReleaseLock { file_id, client_id } => {
+                metadata_op::Operation::ReleaseLock(metadata_op::ReleaseLock {
+                    file_id: uuid_to_bytes(file_id),
+                    client_id,
+                })
+            }
+            RaftMetadataOp::ExtendLock { file_id, client_id } => {
+                metadata_op::Operation::ExtendLock(metadata_op::ExtendLock {
+                    file_id: uuid_to_bytes(file_id),
+                    client_id,
+                })
+            }
+            RaftMetadataOp::AddNode { node_id, address } => {
+                metadata_op::Operation::AddNode(metadata_op::AddNode { node_id, address })
+            }
+            RaftMetadataOp::RemoveNode { node_id } => {
+                metadata_op::Operation::RemoveNode(metadata_op::RemoveNode { node_id })
+            }
+        };
+
+        ProtoMetadataOp {
+            operation: Some(operation),
+        }
+    }
+}
+
+impl TryFrom<ProtoMetadataOp> for RaftMetadataOp {
+    type Error = ProtoError;
+
+    fn try_from(proto: ProtoMetadataOp) -> Result<Self> {
+        let operation = proto
+            .operation
+            .ok_or_else(|| ProtoError::MissingField("operation".to_string()))?;
+
+        Ok(match operation {
+            metadata_op::Operation::CreateFile(op) => {
+                let metadata = op
+                    .metadata
+                    .ok_or_else(|| ProtoError::MissingField("metadata".to_string()))?;
+                RaftMetadataOp::CreateFile {
+                    metadata: metadata.try_into()?,
+                }
+            }
+            metadata_op::Operation::UpdateFile(op) => RaftMetadataOp::UpdateFile {
+                file_id: bytes_to_uuid(&op.file_id)?,
+                metadata: op
+                    .metadata
+                    .ok_or_else(|| ProtoError::MissingField("metadata".to_string()))?
+                    .try_into()?,
+            },
+            metadata_op::Operation::DeleteFile(op) => RaftMetadataOp::DeleteFile {
+                file_id: bytes_to_uuid(&op.file_id)?,
+            },
+            metadata_op::Operation::RegisterChunk(op) => RaftMetadataOp::RegisterChunk {
+                chunk_id: bytes_to_uuid(&op.chunk_id)?,
+                node_id: op.node_id,
+                stripe_id: bytes_to_uuid(&op.stripe_id)?,
+                file_id: bytes_to_uuid(&op.file_id)?,
+            },
+            metadata_op::Operation::UpdateChunkLocation(op) => {
+                RaftMetadataOp::UpdateChunkLocation {
+                    chunk_id: bytes_to_uuid(&op.chunk_id)?,
+                    new_node_id: op.new_node_id,
+                }
+            }
+            metadata_op::Operation::RemoveChunk(op) => RaftMetadataOp::RemoveChunk {
+                chunk_id: bytes_to_uuid(&op.chunk_id)?,
+            },
+            metadata_op::Operation::AcquireLock(op) => RaftMetadataOp::AcquireLock {
+                file_id: bytes_to_uuid(&op.file_id)?,
+                lock_type: op.lock_type.try_into()?,
+                client_id: op.client_id,
+            },
+            metadata_op::Operation::ReleaseLock(op) => RaftMetadataOp::ReleaseLock {
+                file_id: bytes_to_uuid(&op.file_id)?,
+                client_id: op.client_id,
+            },
+            metadata_op::Operation::ExtendLock(op) => RaftMetadataOp::ExtendLock {
+                file_id: bytes_to_uuid(&op.file_id)?,
+                client_id: op.client_id,
+            },
+            metadata_op::Operation::AddNode(op) => RaftMetadataOp::AddNode {
+                node_id: op.node_id,
+                address: op.address,
+            },
+            metadata_op::Operation::RemoveNode(op) => RaftMetadataOp::RemoveNode {
+                node_id: op.node_id,
+            },
+        })
+    }
+}
+
+// ============================================================================
+// MetadataOpResponse Conversion
+// ============================================================================
+
+impl From<RaftMetadataOpResponse> for ProtoMetadataOpResponse {
+    fn from(response: RaftMetadataOpResponse) -> Self {
+        match response {
+            RaftMetadataOpResponse::Success => ProtoMetadataOpResponse {
+                success: true,
+                error_message: String::new(),
+            },
+            RaftMetadataOpResponse::Error(msg) => ProtoMetadataOpResponse {
+                success: false,
+                error_message: msg,
+            },
+        }
+    }
+}
+
+impl From<ProtoMetadataOpResponse> for RaftMetadataOpResponse {
+    fn from(proto: ProtoMetadataOpResponse) -> Self {
+        if proto.success {
+            RaftMetadataOpResponse::Success
+        } else {
+            RaftMetadataOpResponse::Error(proto.error_message)
+        }
+    }
+}
+
+// ============================================================================
+// Serialization Helpers
+// ============================================================================
+
+/// Serialize a MetadataOp to protobuf bytes
+pub fn serialize_metadata_op(op: &RaftMetadataOp) -> Result<Vec<u8>> {
+    let proto: ProtoMetadataOp = op.clone().into();
+    let mut buf = Vec::new();
+    proto.encode(&mut buf)?;
+    Ok(buf)
+}
+
+/// Deserialize a MetadataOp from protobuf bytes
+pub fn deserialize_metadata_op(bytes: &[u8]) -> Result<RaftMetadataOp> {
+    let proto = ProtoMetadataOp::decode(bytes)?;
+    proto.try_into()
+}
+
+/// Serialize a MetadataOpResponse to protobuf bytes
+pub fn serialize_response(response: &RaftMetadataOpResponse) -> Result<Vec<u8>> {
+    let proto: ProtoMetadataOpResponse = response.clone().into();
+    let mut buf = Vec::new();
+    proto.encode(&mut buf)?;
+    Ok(buf)
+}
+
+/// Deserialize a MetadataOpResponse from protobuf bytes
+pub fn deserialize_response(bytes: &[u8]) -> Result<RaftMetadataOpResponse> {
+    let proto = ProtoMetadataOpResponse::decode(bytes)?;
+    Ok(proto.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_uuid_roundtrip() {
+        let uuid = Uuid::new_v4();
+        let bytes = uuid_to_bytes(uuid);
+        let recovered = bytes_to_uuid(&bytes).unwrap();
+        assert_eq!(uuid, recovered);
+    }
+
+    #[test]
+    fn test_lock_type_conversion() {
+        assert_eq!(
+            RaftLockType::Read,
+            RaftLockType::try_from(ProtoLockType::from(RaftLockType::Read)).unwrap()
+        );
+        assert_eq!(
+            RaftLockType::Write,
+            RaftLockType::try_from(ProtoLockType::from(RaftLockType::Write)).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_metadata_op_roundtrip() {
+        let file_id = Uuid::new_v4();
+        let op = RaftMetadataOp::DeleteFile { file_id };
+
+        let bytes = serialize_metadata_op(&op).unwrap();
+        let recovered = deserialize_metadata_op(&bytes).unwrap();
+
+        match recovered {
+            RaftMetadataOp::DeleteFile {
+                file_id: recovered_id,
+            } => {
+                assert_eq!(file_id, recovered_id);
+            }
+            _ => panic!("Wrong operation type"),
+        }
+    }
+
+    #[test]
+    fn test_response_conversion() {
+        let success = RaftMetadataOpResponse::Success;
+        let proto: ProtoMetadataOpResponse = success.into();
+        assert!(proto.success);
+        assert!(proto.error_message.is_empty());
+
+        let error = RaftMetadataOpResponse::Error("test error".to_string());
+        let proto: ProtoMetadataOpResponse = error.into();
+        assert!(!proto.success);
+        assert_eq!(proto.error_message, "test error");
+    }
+}

--- a/src/transport/codec.rs
+++ b/src/transport/codec.rs
@@ -1,0 +1,102 @@
+//! Protobuf encoding/decoding utilities for Raft messages
+//!
+//! This module provides helper functions to serialize and deserialize
+//! Raft RPC messages using protobuf.
+
+use crate::raft::proto_types::proto::{RaftRequest, RaftResponse};
+use crate::transport::{Result, TransportError};
+use prost::Message;
+
+/// Encode a RaftRequest to protobuf bytes
+pub fn encode_raft_request(req: &RaftRequest) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    req.encode(&mut buf)
+        .map_err(|e| TransportError::Serialization(format!("Failed to encode request: {}", e)))?;
+    Ok(buf)
+}
+
+/// Decode a RaftRequest from protobuf bytes
+pub fn decode_raft_request(bytes: &[u8]) -> Result<RaftRequest> {
+    RaftRequest::decode(bytes)
+        .map_err(|e| TransportError::Serialization(format!("Failed to decode request: {}", e)))
+}
+
+/// Encode a RaftResponse to protobuf bytes
+pub fn encode_raft_response(resp: &RaftResponse) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    resp.encode(&mut buf)
+        .map_err(|e| TransportError::Serialization(format!("Failed to encode response: {}", e)))?;
+    Ok(buf)
+}
+
+/// Decode a RaftResponse from protobuf bytes
+pub fn decode_raft_response(bytes: &[u8]) -> Result<RaftResponse> {
+    RaftResponse::decode(bytes)
+        .map_err(|e| TransportError::Serialization(format!("Failed to decode response: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raft::proto_types::proto::{
+        raft_request, raft_response, AppendEntriesRequest, AppendEntriesResponse,
+    };
+
+    #[test]
+    fn test_request_encode_decode_roundtrip() {
+        let request = RaftRequest {
+            request: Some(raft_request::Request::AppendEntries(AppendEntriesRequest {
+                term: 1,
+                leader_id: 1,
+                prev_log_index: 0,
+                prev_log_term: 0,
+                entries: vec![],
+                leader_commit: 0,
+            })),
+        };
+
+        let encoded = encode_raft_request(&request).unwrap();
+        let decoded = decode_raft_request(&encoded).unwrap();
+
+        assert!(decoded.request.is_some());
+        match decoded.request.unwrap() {
+            raft_request::Request::AppendEntries(req) => {
+                assert_eq!(req.term, 1);
+                assert_eq!(req.leader_id, 1);
+            }
+            _ => panic!("Wrong request type"),
+        }
+    }
+
+    #[test]
+    fn test_response_encode_decode_roundtrip() {
+        let response = RaftResponse {
+            response: Some(raft_response::Response::AppendEntries(
+                AppendEntriesResponse {
+                    term: 1,
+                    success: true,
+                    conflict: None,
+                },
+            )),
+        };
+
+        let encoded = encode_raft_response(&response).unwrap();
+        let decoded = decode_raft_response(&encoded).unwrap();
+
+        assert!(decoded.response.is_some());
+        match decoded.response.unwrap() {
+            raft_response::Response::AppendEntries(resp) => {
+                assert_eq!(resp.term, 1);
+                assert!(resp.success);
+            }
+            _ => panic!("Wrong response type"),
+        }
+    }
+
+    #[test]
+    fn test_decode_invalid_data() {
+        let invalid_data = vec![0xFF, 0xFF, 0xFF];
+        assert!(decode_raft_request(&invalid_data).is_err());
+        assert!(decode_raft_response(&invalid_data).is_err());
+    }
+}

--- a/src/transport/libp2p_network.rs
+++ b/src/transport/libp2p_network.rs
@@ -1,0 +1,168 @@
+//! libp2p-based network transport for Raft consensus
+//!
+//! This module provides a libp2p network implementation that supports:
+//! - TCP transport with noise encryption
+//! - Request-response protocol for Raft RPCs
+//! - Static peer configuration
+//! - Connection management and automatic reconnection
+
+use super::{PeerInfo, Result, TransportError};
+use std::collections::HashMap;
+use std::time::Duration;
+
+/// Network configuration for libp2p transport
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct NetworkConfig {
+    /// This node's ID
+    pub node_id: u64,
+
+    /// Listen address (e.g., "/ip4/0.0.0.0/tcp/3000")
+    pub listen_address: String,
+
+    /// Static peer list
+    pub peers: Vec<PeerInfo>,
+
+    /// Request timeout in milliseconds
+    #[serde(default = "default_request_timeout")]
+    pub request_timeout_ms: u64,
+
+    /// Connection timeout in milliseconds
+    #[serde(default = "default_connection_timeout")]
+    pub connection_timeout_ms: u64,
+
+    /// Maximum number of connection retries
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
+}
+
+fn default_request_timeout() -> u64 {
+    5000 // 5 seconds
+}
+
+fn default_connection_timeout() -> u64 {
+    10000 // 10 seconds
+}
+
+fn default_max_retries() -> u32 {
+    3
+}
+
+impl NetworkConfig {
+    /// Create a new network configuration
+    pub fn new(node_id: u64, listen_address: String, peers: Vec<PeerInfo>) -> Self {
+        Self {
+            node_id,
+            listen_address,
+            peers,
+            request_timeout_ms: default_request_timeout(),
+            connection_timeout_ms: default_connection_timeout(),
+            max_retries: default_max_retries(),
+        }
+    }
+
+    /// Validate the configuration
+    pub fn validate(&self) -> Result<()> {
+        if self.listen_address.is_empty() {
+            return Err(TransportError::Config(
+                "listen_address cannot be empty".to_string(),
+            ));
+        }
+
+        if self.request_timeout_ms == 0 {
+            return Err(TransportError::Config(
+                "request_timeout_ms must be > 0".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Get request timeout as Duration
+    pub fn request_timeout(&self) -> Duration {
+        Duration::from_millis(self.request_timeout_ms)
+    }
+
+    /// Get connection timeout as Duration
+    pub fn connection_timeout(&self) -> Duration {
+        Duration::from_millis(self.connection_timeout_ms)
+    }
+}
+
+/// libp2p network transport implementation
+///
+/// This will be implemented in subsequent iterations to provide:
+/// - Raft RPC handling (AppendEntries, Vote, InstallSnapshot)
+/// - Connection pooling and management
+/// - Automatic peer discovery from static configuration
+/// - Health monitoring and reconnection
+pub struct Libp2pNetwork {
+    config: NetworkConfig,
+    _peer_addresses: HashMap<u64, String>,
+}
+
+impl Libp2pNetwork {
+    /// Create a new libp2p network instance
+    pub fn new(config: NetworkConfig) -> Result<Self> {
+        config.validate()?;
+
+        // Build peer address map
+        let peer_addresses: HashMap<u64, String> = config
+            .peers
+            .iter()
+            .map(|p| (p.node_id, p.address.clone()))
+            .collect();
+
+        Ok(Self {
+            config,
+            _peer_addresses: peer_addresses,
+        })
+    }
+
+    /// Start the network transport
+    pub async fn start(&mut self) -> Result<()> {
+        // TODO: Initialize libp2p transport
+        // TODO: Set up request-response protocol
+        // TODO: Start listening on configured address
+        // TODO: Connect to configured peers
+        tracing::info!(
+            "Starting libp2p network on {} for node {}",
+            self.config.listen_address,
+            self.config.node_id
+        );
+
+        Ok(())
+    }
+
+    /// Stop the network transport
+    pub async fn stop(&mut self) -> Result<()> {
+        tracing::info!("Stopping libp2p network for node {}", self.config.node_id);
+        Ok(())
+    }
+
+    /// Get the network configuration
+    pub fn config(&self) -> &NetworkConfig {
+        &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_network_config_validation() {
+        let config = NetworkConfig::new(1, "/ip4/127.0.0.1/tcp/3000".to_string(), vec![]);
+        assert!(config.validate().is_ok());
+
+        let invalid_config = NetworkConfig::new(1, "".to_string(), vec![]);
+        assert!(invalid_config.validate().is_err());
+    }
+
+    #[test]
+    fn test_network_config_timeouts() {
+        let config = NetworkConfig::new(1, "/ip4/127.0.0.1/tcp/3000".to_string(), vec![]);
+
+        assert_eq!(config.request_timeout(), Duration::from_millis(5000));
+        assert_eq!(config.connection_timeout(), Duration::from_millis(10000));
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,0 +1,68 @@
+//! Network transport layer for WormFS
+//!
+//! This module provides the network transport implementation for Raft consensus
+//! and other distributed operations. It uses libp2p for peer-to-peer networking
+//! with support for:
+//!
+//! - TCP transport with noise encryption
+//! - Static peer configuration
+//! - Request-response protocol for Raft RPCs
+//! - Peer health monitoring and connection management
+//! - Automatic reconnection on failures
+
+pub mod codec;
+pub mod libp2p_network;
+pub mod peer_manager;
+pub mod protocol;
+
+pub use codec::{
+    decode_raft_request, decode_raft_response, encode_raft_request, encode_raft_response,
+};
+pub use libp2p_network::{Libp2pNetwork, NetworkConfig};
+pub use peer_manager::{PeerHealth, PeerManager, PeerStatus};
+pub use protocol::{RaftCodec, RaftProtocol};
+
+use std::fmt;
+
+/// Network transport error types
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error("Connection error: {0}")]
+    Connection(String),
+
+    #[error("Peer not found: {0}")]
+    PeerNotFound(u64),
+
+    #[error("Timeout waiting for response")]
+    Timeout,
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    #[error("Network error: {0}")]
+    Network(String),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Configuration error: {0}")]
+    Config(String),
+}
+
+pub type Result<T> = std::result::Result<T, TransportError>;
+
+/// Peer information for static configuration
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PeerInfo {
+    /// Node ID
+    pub node_id: u64,
+
+    /// Network address (e.g., "/ip4/127.0.0.1/tcp/3000")
+    pub address: String,
+}
+
+impl fmt::Display for PeerInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Peer {} @ {}", self.node_id, self.address)
+    }
+}

--- a/src/transport/peer_manager.rs
+++ b/src/transport/peer_manager.rs
@@ -1,0 +1,286 @@
+//! Peer health monitoring and connection management
+//!
+//! This module tracks peer connectivity and health status,
+//! enabling automatic reconnection and failover detection.
+
+use super::PeerInfo;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Peer connection status
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerStatus {
+    /// Connected and healthy
+    Connected,
+
+    /// Disconnected but attempting reconnection
+    Disconnected,
+
+    /// Connection failed after max retries
+    Failed,
+
+    /// Not yet attempted connection
+    Unknown,
+}
+
+/// Peer health information
+#[derive(Debug, Clone)]
+pub struct PeerHealth {
+    /// Peer information
+    pub peer: PeerInfo,
+
+    /// Current connection status
+    pub status: PeerStatus,
+
+    /// Last successful communication timestamp
+    pub last_seen: Option<Instant>,
+
+    /// Number of consecutive failures
+    pub failure_count: u32,
+
+    /// Round-trip time in milliseconds
+    pub rtt_ms: Option<u64>,
+}
+
+impl PeerHealth {
+    /// Create a new peer health tracker
+    pub fn new(peer: PeerInfo) -> Self {
+        Self {
+            peer,
+            status: PeerStatus::Unknown,
+            last_seen: None,
+            failure_count: 0,
+            rtt_ms: None,
+        }
+    }
+
+    /// Check if the peer is healthy (connected recently)
+    pub fn is_healthy(&self, max_age: Duration) -> bool {
+        if self.status != PeerStatus::Connected {
+            return false;
+        }
+
+        if let Some(last_seen) = self.last_seen {
+            last_seen.elapsed() < max_age
+        } else {
+            false
+        }
+    }
+
+    /// Mark peer as connected
+    pub fn mark_connected(&mut self, rtt_ms: Option<u64>) {
+        self.status = PeerStatus::Connected;
+        self.last_seen = Some(Instant::now());
+        self.failure_count = 0;
+        self.rtt_ms = rtt_ms;
+    }
+
+    /// Mark peer as disconnected
+    pub fn mark_disconnected(&mut self) {
+        self.status = PeerStatus::Disconnected;
+        self.failure_count += 1;
+    }
+
+    /// Mark peer as failed
+    pub fn mark_failed(&mut self) {
+        self.status = PeerStatus::Failed;
+    }
+}
+
+/// Peer manager for tracking and monitoring peer health
+pub struct PeerManager {
+    /// Map of node_id to peer health
+    peers: HashMap<u64, PeerHealth>,
+
+    /// Maximum time since last seen before considering unhealthy
+    health_timeout: Duration,
+
+    /// Maximum connection failures before marking as failed
+    max_failures: u32,
+}
+
+impl PeerManager {
+    /// Create a new peer manager
+    pub fn new(peers: Vec<PeerInfo>, health_timeout: Duration, max_failures: u32) -> Self {
+        let peer_health: HashMap<u64, PeerHealth> = peers
+            .into_iter()
+            .map(|p| {
+                let node_id = p.node_id;
+                (node_id, PeerHealth::new(p))
+            })
+            .collect();
+
+        Self {
+            peers: peer_health,
+            health_timeout,
+            max_failures,
+        }
+    }
+
+    /// Get peer health information
+    pub fn get_peer(&self, node_id: u64) -> Option<&PeerHealth> {
+        self.peers.get(&node_id)
+    }
+
+    /// Get mutable peer health information
+    pub fn get_peer_mut(&mut self, node_id: u64) -> Option<&mut PeerHealth> {
+        self.peers.get_mut(&node_id)
+    }
+
+    /// Get all peers
+    pub fn all_peers(&self) -> impl Iterator<Item = &PeerHealth> {
+        self.peers.values()
+    }
+
+    /// Get healthy peers
+    pub fn healthy_peers(&self) -> impl Iterator<Item = &PeerHealth> {
+        self.peers
+            .values()
+            .filter(|p| p.is_healthy(self.health_timeout))
+    }
+
+    /// Count healthy peers
+    pub fn healthy_count(&self) -> usize {
+        self.healthy_peers().count()
+    }
+
+    /// Update peer status after successful communication
+    pub fn record_success(&mut self, node_id: u64, rtt_ms: Option<u64>) {
+        if let Some(peer) = self.peers.get_mut(&node_id) {
+            peer.mark_connected(rtt_ms);
+            tracing::debug!("Peer {} marked as connected", node_id);
+        }
+    }
+
+    /// Update peer status after failed communication
+    pub fn record_failure(&mut self, node_id: u64) {
+        if let Some(peer) = self.peers.get_mut(&node_id) {
+            peer.mark_disconnected();
+
+            if peer.failure_count >= self.max_failures {
+                peer.mark_failed();
+                tracing::warn!(
+                    "Peer {} marked as failed after {} consecutive failures",
+                    node_id,
+                    peer.failure_count
+                );
+            } else {
+                tracing::debug!("Peer {} failure count: {}", node_id, peer.failure_count);
+            }
+        }
+    }
+
+    /// Reset a failed peer to allow reconnection attempts
+    pub fn reset_peer(&mut self, node_id: u64) {
+        if let Some(peer) = self.peers.get_mut(&node_id) {
+            peer.status = PeerStatus::Unknown;
+            peer.failure_count = 0;
+            tracing::info!("Peer {} reset for reconnection", node_id);
+        }
+    }
+
+    /// Get peer statistics
+    pub fn stats(&self) -> PeerStats {
+        let total = self.peers.len();
+        let connected = self
+            .peers
+            .values()
+            .filter(|p| p.status == PeerStatus::Connected)
+            .count();
+        let disconnected = self
+            .peers
+            .values()
+            .filter(|p| p.status == PeerStatus::Disconnected)
+            .count();
+        let failed = self
+            .peers
+            .values()
+            .filter(|p| p.status == PeerStatus::Failed)
+            .count();
+        let unknown = self
+            .peers
+            .values()
+            .filter(|p| p.status == PeerStatus::Unknown)
+            .count();
+        let healthy = self.healthy_count();
+
+        PeerStats {
+            total,
+            connected,
+            disconnected,
+            failed,
+            unknown,
+            healthy,
+        }
+    }
+}
+
+/// Peer statistics
+#[derive(Debug, Clone)]
+pub struct PeerStats {
+    pub total: usize,
+    pub connected: usize,
+    pub disconnected: usize,
+    pub failed: usize,
+    pub unknown: usize,
+    pub healthy: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_peer(node_id: u64) -> PeerInfo {
+        PeerInfo {
+            node_id,
+            address: format!("/ip4/127.0.0.1/tcp/{}", 3000 + node_id),
+        }
+    }
+
+    #[test]
+    fn test_peer_health_lifecycle() {
+        let mut health = PeerHealth::new(create_test_peer(1));
+
+        assert_eq!(health.status, PeerStatus::Unknown);
+        assert!(!health.is_healthy(Duration::from_secs(10)));
+
+        health.mark_connected(Some(50));
+        assert_eq!(health.status, PeerStatus::Connected);
+        assert!(health.is_healthy(Duration::from_secs(10)));
+        assert_eq!(health.rtt_ms, Some(50));
+        assert_eq!(health.failure_count, 0);
+
+        health.mark_disconnected();
+        assert_eq!(health.status, PeerStatus::Disconnected);
+        assert_eq!(health.failure_count, 1);
+
+        health.mark_failed();
+        assert_eq!(health.status, PeerStatus::Failed);
+    }
+
+    #[test]
+    fn test_peer_manager() {
+        let peers = vec![
+            create_test_peer(1),
+            create_test_peer(2),
+            create_test_peer(3),
+        ];
+
+        let mut manager = PeerManager::new(peers, Duration::from_secs(10), 3);
+
+        assert_eq!(manager.all_peers().count(), 3);
+        assert_eq!(manager.healthy_count(), 0);
+
+        manager.record_success(1, Some(50));
+        assert_eq!(manager.healthy_count(), 1);
+
+        manager.record_failure(2);
+        manager.record_failure(2);
+        manager.record_failure(2);
+
+        let stats = manager.stats();
+        assert_eq!(stats.total, 3);
+        assert_eq!(stats.connected, 1);
+        assert_eq!(stats.failed, 1);
+    }
+}

--- a/src/transport/protocol.rs
+++ b/src/transport/protocol.rs
@@ -1,0 +1,272 @@
+//! libp2p request-response protocol definition for Raft RPCs
+//!
+//! This module defines the protocol and codec for Raft message exchange
+//! over libp2p's request-response protocol.
+
+use crate::raft::proto_types::proto::{RaftRequest, RaftResponse};
+use crate::transport::codec::{
+    decode_raft_request, decode_raft_response, encode_raft_request, encode_raft_response,
+};
+use async_trait::async_trait;
+use futures::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use libp2p::request_response::Codec;
+use std::io;
+
+/// The Raft protocol name for libp2p
+#[derive(Debug, Clone)]
+pub struct RaftProtocol;
+
+impl AsRef<str> for RaftProtocol {
+    fn as_ref(&self) -> &str {
+        "/wormfs/raft/1.0.0"
+    }
+}
+
+/// Codec for encoding/decoding Raft messages over libp2p
+#[derive(Debug, Clone)]
+pub struct RaftCodec;
+
+impl Default for RaftCodec {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RaftCodec {
+    /// Create a new RaftCodec
+    pub fn new() -> Self {
+        RaftCodec
+    }
+
+    /// Maximum message size (10MB)
+    const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
+}
+
+#[async_trait]
+impl Codec for RaftCodec {
+    type Protocol = RaftProtocol;
+    type Request = RaftRequest;
+    type Response = RaftResponse;
+
+    async fn read_request<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+    ) -> io::Result<Self::Request>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        // Read message length (4 bytes, big-endian)
+        let mut len_buf = [0u8; 4];
+        io.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+
+        // Check message size limit
+        if len > Self::MAX_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Message too large: {} bytes (max: {})",
+                    len,
+                    Self::MAX_MESSAGE_SIZE
+                ),
+            ));
+        }
+
+        // Read message data
+        let mut buf = vec![0u8; len];
+        io.read_exact(&mut buf).await?;
+
+        // Decode protobuf
+        decode_raft_request(&buf).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Failed to decode request: {}", e),
+            )
+        })
+    }
+
+    async fn read_response<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+    ) -> io::Result<Self::Response>
+    where
+        T: AsyncRead + Unpin + Send,
+    {
+        // Read message length (4 bytes, big-endian)
+        let mut len_buf = [0u8; 4];
+        io.read_exact(&mut len_buf).await?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+
+        // Check message size limit
+        if len > Self::MAX_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Message too large: {} bytes (max: {})",
+                    len,
+                    Self::MAX_MESSAGE_SIZE
+                ),
+            ));
+        }
+
+        // Read message data
+        let mut buf = vec![0u8; len];
+        io.read_exact(&mut buf).await?;
+
+        // Decode protobuf
+        decode_raft_response(&buf).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Failed to decode response: {}", e),
+            )
+        })
+    }
+
+    async fn write_request<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+        req: Self::Request,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        // Encode protobuf
+        let data = encode_raft_request(&req).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Failed to encode request: {}", e),
+            )
+        })?;
+
+        // Check message size limit
+        if data.len() > Self::MAX_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Message too large: {} bytes (max: {})",
+                    data.len(),
+                    Self::MAX_MESSAGE_SIZE
+                ),
+            ));
+        }
+
+        // Write message length (4 bytes, big-endian)
+        let len = data.len() as u32;
+        io.write_all(&len.to_be_bytes()).await?;
+
+        // Write message data
+        io.write_all(&data).await?;
+        io.flush().await?;
+
+        Ok(())
+    }
+
+    async fn write_response<T>(
+        &mut self,
+        _protocol: &Self::Protocol,
+        io: &mut T,
+        resp: Self::Response,
+    ) -> io::Result<()>
+    where
+        T: AsyncWrite + Unpin + Send,
+    {
+        // Encode protobuf
+        let data = encode_raft_response(&resp).map_err(|e| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Failed to encode response: {}", e),
+            )
+        })?;
+
+        // Check message size limit
+        if data.len() > Self::MAX_MESSAGE_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Message too large: {} bytes (max: {})",
+                    data.len(),
+                    Self::MAX_MESSAGE_SIZE
+                ),
+            ));
+        }
+
+        // Write message length (4 bytes, big-endian)
+        let len = data.len() as u32;
+        io.write_all(&len.to_be_bytes()).await?;
+
+        // Write message data
+        io.write_all(&data).await?;
+        io.flush().await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::raft::proto_types::proto::{raft_request, AppendEntriesRequest};
+    use futures::io::Cursor;
+
+    #[tokio::test]
+    async fn test_request_write_read_roundtrip() {
+        let mut codec = RaftCodec::new();
+        let protocol = RaftProtocol;
+
+        let request = RaftRequest {
+            request: Some(raft_request::Request::AppendEntries(AppendEntriesRequest {
+                term: 42,
+                leader_id: 1,
+                prev_log_index: 10,
+                prev_log_term: 5,
+                entries: vec![],
+                leader_commit: 8,
+            })),
+        };
+
+        // Write request to buffer
+        let mut buffer = Vec::new();
+        codec
+            .write_request(&protocol, &mut buffer, request.clone())
+            .await
+            .unwrap();
+
+        // Read request back
+        let mut cursor = Cursor::new(buffer);
+        let decoded = codec.read_request(&protocol, &mut cursor).await.unwrap();
+
+        // Verify
+        assert!(decoded.request.is_some());
+        match decoded.request.unwrap() {
+            raft_request::Request::AppendEntries(req) => {
+                assert_eq!(req.term, 42);
+                assert_eq!(req.leader_id, 1);
+                assert_eq!(req.prev_log_index, 10);
+            }
+            _ => panic!("Wrong request type"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_message_size_limit() {
+        let mut codec = RaftCodec::new();
+        let protocol = RaftProtocol;
+
+        // Create a message that's too large
+        let large_data = vec![0u8; RaftCodec::MAX_MESSAGE_SIZE + 1];
+
+        // Try to read a message with size > MAX_MESSAGE_SIZE
+        let mut buffer = Vec::new();
+        buffer.extend_from_slice(&((RaftCodec::MAX_MESSAGE_SIZE + 1) as u32).to_be_bytes());
+        buffer.extend_from_slice(&large_data);
+
+        let mut cursor = Cursor::new(buffer);
+        let result = codec.read_request(&protocol, &mut cursor).await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("too large"));
+    }
+}


### PR DESCRIPTION
### Phase 2B.1: Protocol Definition & Codec

**Files:** 
- `src/transport/protocol.rs` (NEW)
- `src/transport/codec.rs` (NEW)

**Purpose:** Define the Raft RPC protocol for libp2p request-response and handle message serialization

**What to implement:**

#### protocol.rs
- Define `RaftProtocol` codec for request-response
- Implement `ProtocolName` trait
- Request/Response message types
- Protocol behavior configuration

```rust
pub struct RaftProtocol;

impl ProtocolName for RaftProtocol {
    fn protocol_name(&self) -> &[u8] {
        b"/wormfs/raft/1.0.0"
    }
}

pub struct RaftCodec;

impl RequestResponseCodec for RaftCodec {
    type Protocol = RaftProtocol;
    type Request = RaftRequest;   // From protobuf
    type Response = RaftResponse; // From protobuf
    
    async fn read_request<T>(...) -> io::Result<Self::Request>;
    async fn read_response<T>(...) -> io::Result<Self::Response>;
    async fn write_request<T>(...) -> io::Result<()>;
    async fn write_response<T>(...) -> io::Result<()>;
}
```

#### codec.rs
- Encode/decode functions for Raft messages
- Error handling for malformed messages
- Integration with prost

```rust
pub fn encode_raft_request(req: &RaftRequest) -> Result<Vec<u8>>;
pub fn decode_raft_request(bytes: &[u8]) -> Result<RaftRequest>;
pub fn encode_raft_response(resp: &RaftResponse) -> Result<Vec<u8>>;
pub fn decode_raft_response(bytes: &[u8]) -> Result<RaftResponse>;
```

**Why this first:** Establishes the communication contract before implementing networking

**Estimated Time:** 1-2 hours
