### PR TITLE
Phase 2B.7 - Initial Work on Efficient Snapshot Transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,7 +328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
- "axum-core 0.3.4",
+ "axum-core",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -343,44 +343,10 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
+ "sync_wrapper",
+ "tower",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.7.0",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -398,27 +364,6 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper 1.0.2",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1687,12 +1632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,7 +1697,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2620,16 +2558,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -4023,29 +3951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,12 +4129,6 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "synstructure"
@@ -4453,6 +4352,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4515,7 +4415,7 @@ checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum 0.6.20",
+ "axum",
  "base64 0.21.7",
  "bytes",
  "h2 0.3.27",
@@ -4528,7 +4428,7 @@ dependencies = [
  "prost",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4568,47 +4468,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "sync_wrapper 1.0.2",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
-dependencies = [
- "bitflags 2.9.4",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4626,7 +4485,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4727,12 +4585,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -5367,7 +5219,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.7.9",
  "bincode",
  "bytes",
  "clap",
@@ -5395,11 +5246,10 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tonic",
  "tonic-build",
- "tower 0.4.13",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 # Async runtime
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = "0.7"
+tokio-stream = { version = "0.1", features = ["sync"] }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
@@ -24,7 +25,18 @@ serde_yaml = "0.9"
 humantime-serde = "1.1"
 
 # Networking
-libp2p = { version = "0.56", features = ["tcp", "noise", "yamux", "gossipsub", "mdns", "kad", "request-response", "dns", "tokio", "macros"] }
+libp2p = { version = "0.56", features = [
+    "tcp",
+    "noise",
+    "yamux",
+    "gossipsub",
+    "mdns",
+    "kad",
+    "request-response",
+    "dns",
+    "tokio",
+    "macros",
+] }
 tonic = "0.10"
 tonic-build = "0.10"
 prost = "0.12"
@@ -83,11 +95,6 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["fileapi", "winbase"] }
 
-# Web interface
-axum = "0.7"
-tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "fs"] }
-
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1.4"
@@ -121,10 +128,13 @@ debug = true
 debug = true
 
 [workspace]
-members = [
-    ".",
-]
+members = ["."]
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+# Clippy configuration to suppress warnings in generated code
+[lints.clippy]
+match_single_binding = "allow"
+mixed_attributes_style = "allow"

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,10 @@
 // This script generates Rust code from protobuf definitions
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Compile protobuf files
+    // Compile protobuf files with clippy suppressions for generated code
     tonic_build::configure()
-        .build_server(false) // We don't need gRPC server code yet (Phase 3A)
-        .build_client(false) // We don't need gRPC client code yet (Phase 3A)
+        .build_server(true) // Generate gRPC server code for SnapshotTransferService
+        .build_client(true) // Generate gRPC client code for SnapshotTransferService
         .compile(&["proto/wormfs.proto"], &["proto"])?;
 
     // Tell cargo to rerun this build script if the proto file changes

--- a/docs/phase_2b_detailed_plan.md
+++ b/docs/phase_2b_detailed_plan.md
@@ -442,7 +442,7 @@ async fn test_multiple_peers() {
 
 ---
 
-### Chunk 7: Efficient Snapshot Transfer (~300 lines)
+### Chunk 7: Efficient Snapshot Transfer (~300 lines) - PARTIALLY COMPLETED
 
 **Files:**
 - `proto/wormfs.proto` (modify)

--- a/docs/storage_endpoint_plan.md
+++ b/docs/storage_endpoint_plan.md
@@ -1,0 +1,198 @@
+# StorageEndpoint Implementation Plan
+
+## Overview
+
+This document outlines the plan to refactor the gRPC data transfer services into a dedicated `StorageEndpoint` module, separating bulk data transfer concerns from the Raft consensus network layer.
+
+## Architecture Goals
+
+### Separation of Concerns
+- **StorageNetwork** (libp2p): Handles Raft consensus protocol, peer discovery, and control messages
+- **StorageEndpoint** (gRPC): Handles bulk data transfers for snapshots and chunks
+
+### Design Principles
+1. **Single Responsibility**: Each module has one clear purpose
+2. **Loose Coupling**: Components interact through well-defined interfaces
+3. **Extensibility**: Easy to add new data transfer services
+4. **Independent Lifecycle**: Can start/stop services independently
+
+## Component Architecture
+
+```
+StorageEndpoint/
+├── Configuration
+│   ├── bind_address: String (default: "0.0.0.0")
+│   ├── port: u16 (default: 8082)
+│   ├── snapshot_dir: PathBuf
+│   └── tls_config: Option<TlsConfig> (future)
+│
+├── Services
+│   ├── SnapshotTransferService (Phase 2B - current)
+│   │   ├── TransferSnapshot(request) -> Stream<SnapshotChunk>
+│   │   └── Serves snapshots from snapshot_dir
+│   │
+│   └── ChunkDataService (Phase 3A - future)
+│       ├── ReadChunk(chunk_id) -> ChunkData
+│       ├── WriteChunk(chunk_id, data) -> Result
+│       └── ListChunks(file_id) -> Vec<ChunkInfo>
+│
+└── Server Management
+    ├── new(config) -> Self
+    ├── start() -> Result<ServerHandle>
+    ├── stop() -> Result<()>
+    └── endpoint_address() -> String
+```
+
+## Implementation Tasks
+
+### Task 1: Create StorageEndpoint Module Structure
+**Priority: High**
+**Estimated Effort: 2 hours**
+
+Sub-tasks:
+1. Create `src/storage_endpoint/mod.rs`
+2. Define `StorageEndpointConfig` struct
+3. Define `StorageEndpointServer` struct
+4. Add module exports to `src/lib.rs`
+
+Files to create:
+- `src/storage_endpoint/mod.rs`
+- `src/storage_endpoint/config.rs`
+- `src/storage_endpoint/server.rs`
+
+### Task 2: Move SnapshotTransferService
+**Priority: High**
+**Estimated Effort: 1 hour**
+
+Sub-tasks:
+1. Move `SnapshotTransferServiceImpl` from `src/transport/snapshot_transfer.rs` to `src/storage_endpoint/services/snapshot.rs`
+2. Update import paths
+3. Keep `SnapshotTransferClient` in transport module (it's a client utility)
+
+Files to modify:
+- `src/transport/snapshot_transfer.rs` (remove server, keep client)
+- `src/storage_endpoint/services/snapshot.rs` (new file with server)
+- `src/transport/mod.rs` (update exports)
+
+### Task 3: Implement StorageEndpointServer
+**Priority: High**
+**Estimated Effort: 3 hours**
+
+Sub-tasks:
+1. Implement server lifecycle management
+2. Add gRPC server setup with tonic
+3. Register SnapshotTransferService
+4. Implement graceful shutdown
+5. Add health check endpoint
+
+```rust
+pub struct StorageEndpointServer {
+    config: StorageEndpointConfig,
+    server_handle: Option<JoinHandle<Result<(), tonic::transport::Error>>>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl StorageEndpointServer {
+    pub async fn start(&mut self) -> Result<String> {
+        // Build gRPC server
+        // Register services
+        // Return endpoint address
+    }
+    
+    pub async fn stop(&mut self) -> Result<()> {
+        // Send shutdown signal
+        // Wait for graceful termination
+    }
+}
+```
+
+### Task 4: Update NetworkConfig
+**Priority: Medium**
+**Estimated Effort: 1 hour**
+
+Sub-tasks:
+1. Remove `snapshot_server_port` from `NetworkConfig`
+2. Remove `snapshot_dir` from `NetworkConfig`  
+3. Add `storage_endpoint_address: Option<String>` for peers to know where to download from
+4. Update tests to reflect changes
+
+Files to modify:
+- `src/transport/libp2p_network.rs`
+- `tests/transport_tests.rs`
+
+### Task 5: Update Node Initialization
+**Priority: Medium**
+**Estimated Effort: 2 hours**
+
+Sub-tasks:
+1. Update `StorageNode` to create both `StorageNetwork` and `StorageEndpoint`
+2. Start StorageEndpoint before StorageNetwork
+3. Pass endpoint address to components that need it
+4. Update configuration file structure
+
+Files to modify:
+- `src/node/storage_node.rs`
+- `config/storage_node.yaml`
+
+Example configuration:
+```yaml
+network:
+  node_id: 1
+  listen_address: "/ip4/0.0.0.0/tcp/3000"
+  peers: [...]
+
+storage_endpoint:
+  bind_address: "0.0.0.0"
+  port: 8082
+  snapshot_dir: "./data/snapshots"
+```
+
+### Task 6: Modify InstallSnapshot Handling
+**Priority: High**
+**Estimated Effort: 3 hours**
+
+Sub-tasks:
+1. Update `InstallSnapshotRequest` to include `leader_endpoint_address`
+2. Modify leader to include its StorageEndpoint address
+3. Update follower to download from the provided endpoint
+4. Add error handling for endpoint unavailability
+
+Files to modify:
+- `proto/wormfs.proto` (already has `leader_address` field)
+- Raft layer integration (TBD based on implementation)
+
+### Task 7: Add Integration Tests
+**Priority: Medium**
+**Estimated Effort: 3 hours**
+
+Test scenarios:
+1. Start StorageEndpoint and verify it's accessible
+2. Upload and download snapshot via gRPC
+3. Test concurrent downloads
+4. Test shutdown during transfer
+5. Test hash verification
+6. Test retry logic on failure
+
+Files to create:
+- `tests/storage_endpoint_tests.rs`
+
+### Task 8: Documentation
+**Priority: Low**
+**Estimated Effort: 2 hours**
+
+Sub-tasks:
+1. Update architecture documentation
+2. Add usage examples
+3. Document configuration options
+4. Add sequence diagrams for snapshot transfer flow
+
+Files to modify:
+- `docs/implementation.md`
+- `README.md`
+
+## Notes
+
+- This design keeps the transport layer (libp2p) separate from data transfer (gRPC)
+- The StorageEndpoint can evolve independently of the consensus layer
+- Future services can be added without modifying existing code
+- The architecture supports horizontal scaling of storage endpoints

--- a/proto/wormfs.proto
+++ b/proto/wormfs.proto
@@ -154,14 +154,45 @@ message InstallSnapshotRequest {
   uint64 leader_id = 2;
   uint64 last_included_index = 3;
   uint64 last_included_term = 4;
-  uint64 offset = 5;
-  bytes data = 6;
-  bool done = 7;  // Is this the last chunk?
+  
+  // gRPC transfer fields (follower will use SnapshotTransferService to download)
+  string snapshot_id = 5;          // Unique snapshot identifier
+  uint64 size = 6;                 // Total size in bytes
+  string hash = 7;                 // SHA256 hash for verification
+  string leader_address = 8;       // gRPC address to download from
 }
 
 message InstallSnapshotResponse {
   uint64 term = 1;
   bool success = 2;
+  string error_message = 3;        // Optional error details
+}
+
+// ============================================================================
+// Snapshot Transfer Service (for efficient large snapshot transfers)
+// ============================================================================
+
+message SnapshotChunk {
+  string snapshot_id = 1;
+  uint64 offset = 2;
+  bytes data = 3;
+  bool is_last = 4;
+}
+
+message SnapshotTransferRequest {
+  string snapshot_id = 1;
+  uint64 requester_node_id = 2;
+}
+
+message SnapshotTransferResponse {
+  bool success = 1;
+  string error_message = 2;
+  uint64 total_bytes = 3;
+}
+
+service SnapshotTransferService {
+  // Stream snapshot data from leader to follower
+  rpc TransferSnapshot(SnapshotTransferRequest) returns (stream SnapshotChunk);
 }
 
 // ============================================================================

--- a/src/raft/snapshot_store.rs
+++ b/src/raft/snapshot_store.rs
@@ -238,6 +238,58 @@ impl SnapshotStore {
     pub fn snapshot_dir(&self) -> &Path {
         &self.snapshot_dir
     }
+
+    /// Get the path to a specific snapshot's data file
+    pub fn get_snapshot_data_path(&self, snapshot_id: &str) -> Option<PathBuf> {
+        let data_path = self.snapshot_dir.join(format!("{}.data", snapshot_id));
+        if data_path.exists() {
+            Some(data_path)
+        } else {
+            None
+        }
+    }
+
+    /// Get metadata for a specific snapshot
+    pub fn get_snapshot_metadata(
+        &self,
+        snapshot_id: &str,
+    ) -> Result<PersistedSnapshotMeta, io::Error> {
+        let meta_path = self.snapshot_dir.join(format!("{}.meta", snapshot_id));
+        self.load_snapshot_meta(&meta_path)
+    }
+
+    /// Check if a snapshot exists
+    pub fn snapshot_exists(&self, snapshot_id: &str) -> bool {
+        let data_path = self.snapshot_dir.join(format!("{}.data", snapshot_id));
+        let meta_path = self.snapshot_dir.join(format!("{}.meta", snapshot_id));
+        data_path.exists() && meta_path.exists()
+    }
+
+    /// Get path for temporary snapshot file
+    pub fn get_temp_path(&self, snapshot_id: &str) -> PathBuf {
+        self.snapshot_dir.join(format!("{}.tmp", snapshot_id))
+    }
+
+    /// Install a snapshot from a temporary file (atomic move)
+    pub async fn install_snapshot_from_temp(
+        &self,
+        snapshot_id: &str,
+        temp_path: PathBuf,
+        metadata: PersistedSnapshotMeta,
+    ) -> Result<(), io::Error> {
+        // Write metadata file
+        let meta_path = self.snapshot_dir.join(format!("{}.meta", snapshot_id));
+        let meta_json = serde_json::to_string_pretty(&metadata)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        tokio::fs::write(&meta_path, meta_json).await?;
+
+        // Atomically move temporary file to final location
+        let final_path = self.snapshot_dir.join(format!("{}.data", snapshot_id));
+        tokio::fs::rename(&temp_path, &final_path).await?;
+
+        tracing::info!("Installed snapshot '{}' from temporary file", snapshot_id);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/transport/libp2p_network.rs
+++ b/src/transport/libp2p_network.rs
@@ -60,6 +60,14 @@ pub struct NetworkConfig {
     /// When false: only accept connections from pre-configured peer_ids
     #[serde(default = "default_allow_discovery")]
     pub allow_peer_discovery: bool,
+
+    /// Port for gRPC snapshot transfer server
+    #[serde(default = "default_snapshot_server_port")]
+    pub snapshot_server_port: u16,
+
+    /// Directory where snapshots are stored
+    #[serde(default = "default_snapshot_dir")]
+    pub snapshot_dir: String,
 }
 
 fn default_request_timeout() -> u64 {
@@ -78,6 +86,14 @@ fn default_allow_discovery() -> bool {
     false // Default to strict mode for security
 }
 
+fn default_snapshot_server_port() -> u16 {
+    8082 // Default port for snapshot transfers
+}
+
+fn default_snapshot_dir() -> String {
+    "./data/snapshots".to_string()
+}
+
 impl NetworkConfig {
     /// Create a new network configuration
     pub fn new(node_id: u64, listen_address: String, peers: Vec<PeerInfo>) -> Self {
@@ -89,6 +105,8 @@ impl NetworkConfig {
             connection_timeout_ms: default_connection_timeout(),
             max_retries: default_max_retries(),
             allow_peer_discovery: default_allow_discovery(),
+            snapshot_server_port: default_snapshot_server_port(),
+            snapshot_dir: default_snapshot_dir(),
         }
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -14,6 +14,7 @@ pub mod codec;
 pub mod libp2p_network;
 pub mod peer_manager;
 pub mod protocol;
+pub mod snapshot_transfer;
 
 pub use codec::{
     decode_raft_request, decode_raft_response, encode_raft_request, encode_raft_response,
@@ -23,6 +24,10 @@ pub use libp2p_network::{
 };
 pub use peer_manager::{PeerHealth, PeerManager, PeerStats, PeerStatus};
 pub use protocol::{RaftCodec, RaftProtocol};
+pub use snapshot_transfer::{
+    compute_file_hash, SnapshotTransferClient, SnapshotTransferConfig, SnapshotTransferError,
+    SnapshotTransferServiceImpl,
+};
 
 use std::fmt;
 

--- a/src/transport/snapshot_transfer.rs
+++ b/src/transport/snapshot_transfer.rs
@@ -1,0 +1,373 @@
+//! gRPC-based snapshot transfer for efficient Raft snapshot distribution
+//!
+//! This module provides:
+//! - SnapshotTransferService implementation for serving snapshots
+//! - SnapshotTransferClient for downloading snapshots
+//!
+//! Using gRPC for snapshot transfer has several benefits:
+//! - Separation from Raft protocol (doesn't congest message channel)
+//! - Efficient streaming with built-in flow control
+//! - Type-safe API through protobuf definitions
+//! - Consistent with overall architecture (using tonic for all services)
+
+use sha2::{Digest, Sha256};
+use std::io;
+use std::path::PathBuf;
+use tokio::io::AsyncReadExt;
+use tonic::{Request, Response, Status};
+use tracing::{error, info, warn};
+
+use crate::raft::proto_types::proto::{
+    snapshot_transfer_service_server::SnapshotTransferService as SnapshotTransferServiceTrait,
+    SnapshotChunk, SnapshotTransferRequest,
+};
+
+/// Configuration for snapshot transfer server
+#[derive(Debug, Clone)]
+pub struct SnapshotTransferConfig {
+    /// Port to listen on for gRPC requests
+    pub port: u16,
+    /// Local node ID (for authentication)
+    pub node_id: u64,
+    /// Directory where snapshots are stored
+    pub snapshot_dir: PathBuf,
+}
+
+/// gRPC service implementation for serving snapshots to peers
+pub struct SnapshotTransferServiceImpl {
+    config: SnapshotTransferConfig,
+}
+
+impl SnapshotTransferServiceImpl {
+    /// Create a new snapshot transfer service
+    pub fn new(config: SnapshotTransferConfig) -> Self {
+        Self { config }
+    }
+}
+
+#[tonic::async_trait]
+impl SnapshotTransferServiceTrait for SnapshotTransferServiceImpl {
+    type TransferSnapshotStream =
+        tokio_stream::wrappers::ReceiverStream<Result<SnapshotChunk, Status>>;
+
+    async fn transfer_snapshot(
+        &self,
+        request: Request<SnapshotTransferRequest>,
+    ) -> Result<Response<Self::TransferSnapshotStream>, Status> {
+        let req = request.into_inner();
+        let snapshot_id = req.snapshot_id.clone();
+        let requester_node_id = req.requester_node_id;
+
+        info!(
+            "Received snapshot transfer request for '{}' from node {}",
+            snapshot_id, requester_node_id
+        );
+
+        // Build path to snapshot data file
+        let data_path = self
+            .config
+            .snapshot_dir
+            .join(format!("{}.data", snapshot_id));
+
+        // Check if snapshot exists
+        if !data_path.exists() {
+            warn!("Snapshot not found: {}", snapshot_id);
+            return Err(Status::not_found(format!(
+                "Snapshot '{}' not found",
+                snapshot_id
+            )));
+        }
+
+        // Open the file
+        let mut file = tokio::fs::File::open(&data_path).await.map_err(|e| {
+            error!("Failed to open snapshot file {}: {}", snapshot_id, e);
+            Status::internal(format!("Failed to open snapshot: {}", e))
+        })?;
+
+        // Get file size
+        let metadata = file.metadata().await.map_err(|e| {
+            error!("Failed to get file metadata {}: {}", snapshot_id, e);
+            Status::internal(format!("Failed to get metadata: {}", e))
+        })?;
+
+        let total_size = metadata.len();
+        info!(
+            "Serving snapshot '{}' ({} bytes) to node {}",
+            snapshot_id, total_size, requester_node_id
+        );
+
+        // Create channel for streaming
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+        // Spawn task to stream file chunks
+        tokio::spawn(async move {
+            let chunk_size = 64 * 1024; // 64 KB chunks
+            let mut buffer = vec![0u8; chunk_size];
+            let mut offset = 0u64;
+
+            loop {
+                match file.read(&mut buffer).await {
+                    Ok(0) => {
+                        // EOF - send final chunk
+                        let chunk = SnapshotChunk {
+                            snapshot_id: snapshot_id.clone(),
+                            offset,
+                            data: vec![],
+                            is_last: true,
+                        };
+                        let _ = tx.send(Ok(chunk)).await;
+                        info!("Completed streaming snapshot '{}'", snapshot_id);
+                        break;
+                    }
+                    Ok(n) => {
+                        let chunk = SnapshotChunk {
+                            snapshot_id: snapshot_id.clone(),
+                            offset,
+                            data: buffer[..n].to_vec(),
+                            is_last: false,
+                        };
+
+                        if tx.send(Ok(chunk)).await.is_err() {
+                            warn!("Client disconnected during snapshot transfer");
+                            break;
+                        }
+
+                        offset += n as u64;
+                    }
+                    Err(e) => {
+                        error!("Error reading snapshot file: {}", e);
+                        let _ = tx
+                            .send(Err(Status::internal(format!("Read error: {}", e))))
+                            .await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+            rx,
+        )))
+    }
+}
+
+/// Client for downloading snapshots from peers via gRPC
+pub struct SnapshotTransferClient {
+    max_retries: usize,
+}
+
+impl SnapshotTransferClient {
+    /// Create a new snapshot transfer client
+    pub fn new(max_retries: usize) -> Self {
+        Self { max_retries }
+    }
+
+    /// Download a snapshot from a gRPC endpoint with retry logic
+    ///
+    /// Downloads to a temporary file, verifies the hash, then moves to final location
+    pub async fn download_snapshot(
+        &self,
+        grpc_address: &str,
+        snapshot_id: &str,
+        requester_node_id: u64,
+        expected_hash: &str,
+        destination_dir: &std::path::Path,
+    ) -> Result<PathBuf, SnapshotTransferError> {
+        let mut last_error = None;
+
+        for attempt in 1..=self.max_retries {
+            match self
+                .try_download(
+                    grpc_address,
+                    snapshot_id,
+                    requester_node_id,
+                    expected_hash,
+                    destination_dir,
+                )
+                .await
+            {
+                Ok(path) => {
+                    info!(
+                        "Successfully downloaded snapshot '{}' (attempt {}/{})",
+                        snapshot_id, attempt, self.max_retries
+                    );
+                    return Ok(path);
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to download snapshot '{}' (attempt {}/{}): {}",
+                        snapshot_id, attempt, self.max_retries, e
+                    );
+                    last_error = Some(e);
+
+                    if attempt < self.max_retries {
+                        // Exponential backoff
+                        let delay = std::time::Duration::from_secs(2u64.pow(attempt as u32 - 1));
+                        tokio::time::sleep(delay).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or(SnapshotTransferError::MaxRetriesExceeded))
+    }
+
+    /// Single attempt to download a snapshot
+    async fn try_download(
+        &self,
+        grpc_address: &str,
+        snapshot_id: &str,
+        requester_node_id: u64,
+        expected_hash: &str,
+        destination_dir: &std::path::Path,
+    ) -> Result<PathBuf, SnapshotTransferError> {
+        use crate::raft::proto_types::proto::snapshot_transfer_service_client::SnapshotTransferServiceClient;
+
+        info!(
+            "Downloading snapshot '{}' from {}",
+            snapshot_id, grpc_address
+        );
+
+        // Connect to gRPC server
+        let mut client = SnapshotTransferServiceClient::connect(grpc_address.to_string())
+            .await
+            .map_err(|e| SnapshotTransferError::GrpcError(e.to_string()))?;
+
+        // Create request
+        let request = Request::new(SnapshotTransferRequest {
+            snapshot_id: snapshot_id.to_string(),
+            requester_node_id,
+        });
+
+        // Start streaming
+        let mut stream = client
+            .transfer_snapshot(request)
+            .await
+            .map_err(|e| SnapshotTransferError::GrpcError(e.to_string()))?
+            .into_inner();
+
+        // Download to temporary file
+        let temp_path = destination_dir.join(format!("{}.tmp", snapshot_id));
+        let mut temp_file = tokio::fs::File::create(&temp_path).await?;
+
+        // Stream download and compute hash simultaneously
+        let mut hasher = Sha256::new();
+        let mut total_bytes = 0u64;
+
+        while let Some(chunk) = stream
+            .message()
+            .await
+            .map_err(|e| SnapshotTransferError::GrpcError(e.to_string()))?
+        {
+            if !chunk.data.is_empty() {
+                hasher.update(&chunk.data);
+                tokio::io::AsyncWriteExt::write_all(&mut temp_file, &chunk.data).await?;
+                total_bytes += chunk.data.len() as u64;
+            }
+
+            if chunk.is_last {
+                break;
+            }
+        }
+
+        tokio::io::AsyncWriteExt::flush(&mut temp_file).await?;
+        drop(temp_file);
+
+        // Verify hash
+        let computed_hash = format!("{:x}", hasher.finalize());
+        if computed_hash != expected_hash {
+            // Clean up temp file
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            return Err(SnapshotTransferError::HashMismatch {
+                expected: expected_hash.to_string(),
+                actual: computed_hash,
+            });
+        }
+
+        info!(
+            "Downloaded and verified snapshot '{}' ({} bytes)",
+            snapshot_id, total_bytes
+        );
+
+        // Move to final location
+        let final_path = destination_dir.join(format!("{}.data", snapshot_id));
+        tokio::fs::rename(&temp_path, &final_path).await?;
+
+        Ok(final_path)
+    }
+}
+
+/// Errors that can occur during snapshot transfer
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotTransferError {
+    #[error("IO error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error("gRPC error: {0}")]
+    GrpcError(String),
+
+    #[error("Hash mismatch - expected: {expected}, got: {actual}")]
+    HashMismatch { expected: String, actual: String },
+
+    #[error("Max retries exceeded")]
+    MaxRetriesExceeded,
+}
+
+/// Helper function to compute SHA256 hash of a file
+pub async fn compute_file_hash(path: &std::path::Path) -> Result<String, io::Error> {
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 8192];
+
+    loop {
+        let n = file.read(&mut buffer).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buffer[..n]);
+    }
+
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_client_creation() {
+        let client = SnapshotTransferClient::new(3);
+        assert_eq!(client.max_retries, 3);
+    }
+
+    #[tokio::test]
+    async fn test_compute_file_hash() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("test.data");
+
+        // Write test data
+        tokio::fs::write(&test_file, b"test data").await.unwrap();
+
+        // Compute hash
+        let hash = compute_file_hash(&test_file).await.unwrap();
+
+        // Verify it's a valid SHA256 hex string
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[tokio::test]
+    async fn test_hash_verification() {
+        // Test that we can compute consistent hashes
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("test.data");
+
+        tokio::fs::write(&test_file, b"test data").await.unwrap();
+
+        let hash1 = compute_file_hash(&test_file).await.unwrap();
+        let hash2 = compute_file_hash(&test_file).await.unwrap();
+
+        assert_eq!(hash1, hash2);
+    }
+}

--- a/tests/transport_tests.rs
+++ b/tests/transport_tests.rs
@@ -26,6 +26,8 @@ fn create_test_config(node_id: u64, port: u16, peers: Vec<PeerInfo>) -> NetworkC
         connection_timeout_ms: 10000,
         max_retries: 3,
         allow_peer_discovery: true,
+        snapshot_server_port: 8082, // Default test snapshot server port
+        snapshot_dir: format!("./data/test_snapshots/{}", node_id), // Test snapshot directory
     }
 }
 
@@ -69,6 +71,7 @@ fn create_mock_handler(
                                 InstallSnapshotResponse {
                                     term: 1,
                                     success: true,
+                                    error_message: String::new(),
                                 },
                             ),
                         ),


### PR DESCRIPTION
This is only a partial implementation of the new, more efficient, snapshot transfer design. Currently, `InstallSnapshotRequest` embeds snapshot data directly in the Raft message. This works for small metadata snapshots (<1MB) but becomes inefficient for larger snapshots. This adds the foundation for two-phase approach: signaling through Raft, bulk transfer through HTTP/gRPC.

The rest of this change will be delivered via the plan outlined in storage_endpoint_plan.md