### PR TITLE
Implement StorageEndpointServer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,6 +4448,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-health"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f80db390246dfb46553481f6024f0082ba00178ea495dbb99e70ba9a4fafb5e1"
+dependencies = [
+ "async-stream",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5250,6 +5263,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-build",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ libp2p = { version = "0.56", features = [
 ] }
 tonic = "0.10"
 tonic-build = "0.10"
+tonic-health = "0.10"
 prost = "0.12"
 
 # Database

--- a/docs/storage_endpoint_plan.md
+++ b/docs/storage_endpoint_plan.md
@@ -74,7 +74,7 @@ Files to modify:
 - `src/storage_endpoint/services/snapshot.rs` (new file with server)
 - `src/transport/mod.rs` (update exports)
 
-### Task 3: Implement StorageEndpointServer
+### Task 3: Implement StorageEndpointServer - COMPLETED
 **Priority: High**
 **Estimated Effort: 3 hours**
 

--- a/src/storage_endpoint/server.rs
+++ b/src/storage_endpoint/server.rs
@@ -1,9 +1,14 @@
 //! StorageEndpoint gRPC server implementation
 
-use super::{Result, StorageEndpointConfig, StorageEndpointError};
+use super::{Result, SnapshotTransferServiceImpl, StorageEndpointConfig, StorageEndpointError};
+use std::net::SocketAddr;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use tonic::transport::Server;
+use tonic_health::server::{health_reporter, HealthReporter};
 use tracing::{error, info};
+
+use crate::raft::proto_types::proto::snapshot_transfer_service_server::SnapshotTransferServiceServer;
 
 /// StorageEndpoint gRPC server
 ///
@@ -13,6 +18,7 @@ pub struct StorageEndpointServer {
     config: StorageEndpointConfig,
     server_handle: Option<JoinHandle<Result<()>>>,
     shutdown_tx: Option<oneshot::Sender<()>>,
+    health_reporter: Option<HealthReporter>,
 }
 
 impl StorageEndpointServer {
@@ -24,6 +30,7 @@ impl StorageEndpointServer {
             config,
             server_handle: None,
             shutdown_tx: None,
+            health_reporter: None,
         })
     }
 
@@ -43,9 +50,6 @@ impl StorageEndpointServer {
     }
 
     /// Start the gRPC server
-    ///
-    /// This will be fully implemented in Task 3.
-    /// For now, it's a placeholder that validates configuration.
     pub async fn start(&mut self) -> Result<String> {
         if self.is_running() {
             return Err(StorageEndpointError::Server(
@@ -59,15 +63,46 @@ impl StorageEndpointServer {
             self.config.node_id
         );
 
-        // TODO: Task 3 will implement:
-        // 1. Build tonic server
-        // 2. Register SnapshotTransferService
-        // 3. Register future ChunkDataService
-        // 4. Start server in background task
-        // 5. Store server_handle and shutdown_tx
+        // Parse bind address
+        let addr: SocketAddr =
+            self.config.server_address().parse().map_err(|e| {
+                StorageEndpointError::Config(format!("Invalid server address: {}", e))
+            })?;
 
-        // Placeholder validation
-        self.config.validate()?;
+        // Create snapshot transfer service
+        let snapshot_service = SnapshotTransferServiceImpl::new(self.config.clone());
+
+        // Create health reporter
+        let (mut health_reporter, health_service) = health_reporter();
+
+        // Create shutdown channel
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        // Build and configure the gRPC server
+        let server_future = Server::builder()
+            .add_service(health_service)
+            .add_service(SnapshotTransferServiceServer::new(snapshot_service))
+            .serve_with_shutdown(addr, async {
+                shutdown_rx.await.ok();
+                info!("StorageEndpoint server received shutdown signal");
+            });
+
+        // Spawn server in background task
+        let server_handle = tokio::spawn(async move {
+            server_future
+                .await
+                .map_err(|e| StorageEndpointError::GrpcError(e.to_string()))
+        });
+
+        // Set services as serving
+        health_reporter
+            .set_serving::<SnapshotTransferServiceServer<SnapshotTransferServiceImpl>>()
+            .await;
+
+        // Store handles for lifecycle management
+        self.server_handle = Some(server_handle);
+        self.shutdown_tx = Some(shutdown_tx);
+        self.health_reporter = Some(health_reporter);
 
         info!(
             "StorageEndpoint server started successfully at {}",
@@ -78,8 +113,6 @@ impl StorageEndpointServer {
     }
 
     /// Stop the gRPC server gracefully
-    ///
-    /// This will be fully implemented in Task 3.
     pub async fn stop(&mut self) -> Result<()> {
         if !self.is_running() {
             return Ok(());
@@ -90,15 +123,19 @@ impl StorageEndpointServer {
             self.config.node_id
         );
 
-        // TODO: Task 3 will implement:
-        // 1. Send shutdown signal via shutdown_tx
-        // 2. Wait for server_handle to complete
-        // 3. Clean up resources
+        // Mark services as not serving
+        if let Some(mut reporter) = self.health_reporter.take() {
+            reporter
+                .set_not_serving::<SnapshotTransferServiceServer<SnapshotTransferServiceImpl>>()
+                .await;
+        }
 
+        // Send shutdown signal
         if let Some(shutdown_tx) = self.shutdown_tx.take() {
             let _ = shutdown_tx.send(());
         }
 
+        // Wait for server to complete
         if let Some(handle) = self.server_handle.take() {
             match handle.await {
                 Ok(Ok(())) => {
@@ -137,6 +174,7 @@ impl Drop for StorageEndpointServer {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
     #[test]
     fn test_server_creation() {
@@ -172,5 +210,134 @@ mod tests {
         };
         let server = StorageEndpointServer::new(config);
         assert!(server.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_server_lifecycle() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = StorageEndpointConfig::new(1, 18082, temp_dir.path().to_path_buf());
+        let mut server = StorageEndpointServer::new(config).unwrap();
+
+        // Server should not be running initially
+        assert!(!server.is_running());
+
+        // Start the server
+        let addr = server.start().await.unwrap();
+        assert!(addr.contains("18082"));
+        assert!(server.is_running());
+
+        // Give server a moment to bind
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Stop the server
+        server.stop().await.unwrap();
+        assert!(!server.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_cannot_start_twice() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = StorageEndpointConfig::new(1, 18083, temp_dir.path().to_path_buf());
+        let mut server = StorageEndpointServer::new(config).unwrap();
+
+        // Start the server
+        server.start().await.unwrap();
+
+        // Attempting to start again should fail
+        let result = server.start().await;
+        assert!(result.is_err());
+
+        // Cleanup
+        server.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stop_when_not_running() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = StorageEndpointConfig::new(1, 18084, temp_dir.path().to_path_buf());
+        let mut server = StorageEndpointServer::new(config).unwrap();
+
+        // Stopping a non-running server should succeed silently
+        let result = server.stop().await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_health_check_positive() {
+        use tonic::transport::Channel;
+        use tonic_health::pb::health_client::HealthClient;
+        use tonic_health::pb::HealthCheckRequest;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = StorageEndpointConfig::new(1, 18085, temp_dir.path().to_path_buf());
+        let mut server = StorageEndpointServer::new(config).unwrap();
+
+        // Start the server
+        server.start().await.unwrap();
+
+        // Give server time to start
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Connect to the health check endpoint
+        let channel = Channel::from_static("http://127.0.0.1:18085")
+            .connect()
+            .await
+            .unwrap();
+        let mut health_client = HealthClient::new(channel);
+
+        // Check health - should be SERVING
+        let request = tonic::Request::new(HealthCheckRequest {
+            service: "wormfs.SnapshotTransferService".to_string(),
+        });
+        let response = health_client.check(request).await.unwrap();
+        let status = response.into_inner().status;
+
+        // Status 1 = SERVING (from tonic_health::pb::health_check_response::ServingStatus)
+        assert_eq!(status, 1, "Service should be SERVING");
+
+        // Cleanup
+        server.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_health_check_negative() {
+        use tonic::transport::Channel;
+        use tonic_health::pb::health_client::HealthClient;
+        use tonic_health::pb::HealthCheckRequest;
+
+        let temp_dir = TempDir::new().unwrap();
+        let config = StorageEndpointConfig::new(1, 18086, temp_dir.path().to_path_buf());
+        let mut server = StorageEndpointServer::new(config).unwrap();
+
+        // Start the server
+        server.start().await.unwrap();
+
+        // Give server time to start
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Connect to the health check endpoint
+        let channel = Channel::from_static("http://127.0.0.1:18086")
+            .connect()
+            .await
+            .unwrap();
+        let mut health_client = HealthClient::new(channel);
+
+        // Stop the server (this should mark services as NOT_SERVING)
+        server.stop().await.unwrap();
+
+        // Give server time to stop
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Check health - connection should fail since server is stopped
+        let request = tonic::Request::new(HealthCheckRequest {
+            service: "wormfs.SnapshotTransferService".to_string(),
+        });
+        let response = health_client.check(request).await;
+
+        // Should fail with transport error (connection refused/reset)
+        assert!(
+            response.is_err(),
+            "Health check should fail when server is stopped"
+        );
     }
 }


### PR DESCRIPTION
### Task 3: Implement StorageEndpointServer - COMPLETED
**Priority: High**
**Estimated Effort: 3 hours**

Sub-tasks:
1. Implement server lifecycle management
2. Add gRPC server setup with tonic
3. Register SnapshotTransferService
4. Implement graceful shutdown
5. Add health check endpoint

```rust
pub struct StorageEndpointServer {
    config: StorageEndpointConfig,
    server_handle: Option<JoinHandle<Result<(), tonic::transport::Error>>>,
    shutdown_tx: Option<oneshot::Sender<()>>,
}

impl StorageEndpointServer {
    pub async fn start(&mut self) -> Result<String> {
        // Build gRPC server
        // Register services
        // Return endpoint address
    }
    
    pub async fn stop(&mut self) -> Result<()> {
        // Send shutdown signal
        // Wait for graceful termination
    }
}
```
