### PR TITLE
Update NetworkConfig

### DIFF
--- a/docs/storage_endpoint_plan.md
+++ b/docs/storage_endpoint_plan.md
@@ -106,7 +106,7 @@ impl StorageEndpointServer {
 }
 ```
 
-### Task 4: Update NetworkConfig
+### Task 4: Update NetworkConfig - COMPLETED
 **Priority: Medium**
 **Estimated Effort: 1 hour**
 

--- a/src/transport/libp2p_network.rs
+++ b/src/transport/libp2p_network.rs
@@ -61,13 +61,11 @@ pub struct NetworkConfig {
     #[serde(default = "default_allow_discovery")]
     pub allow_peer_discovery: bool,
 
-    /// Port for gRPC snapshot transfer server
-    #[serde(default = "default_snapshot_server_port")]
-    pub snapshot_server_port: u16,
-
-    /// Directory where snapshots are stored
-    #[serde(default = "default_snapshot_dir")]
-    pub snapshot_dir: String,
+    /// Optional StorageEndpoint address for this node
+    /// Format: "http://hostname:port" (e.g., "http://node1.example.com:8082")
+    /// This allows peers to know where to download snapshots/chunks from this node
+    #[serde(default)]
+    pub storage_endpoint_address: Option<String>,
 }
 
 fn default_request_timeout() -> u64 {
@@ -86,14 +84,6 @@ fn default_allow_discovery() -> bool {
     false // Default to strict mode for security
 }
 
-fn default_snapshot_server_port() -> u16 {
-    8082 // Default port for snapshot transfers
-}
-
-fn default_snapshot_dir() -> String {
-    "./data/snapshots".to_string()
-}
-
 impl NetworkConfig {
     /// Create a new network configuration
     pub fn new(node_id: u64, listen_address: String, peers: Vec<PeerInfo>) -> Self {
@@ -105,8 +95,7 @@ impl NetworkConfig {
             connection_timeout_ms: default_connection_timeout(),
             max_retries: default_max_retries(),
             allow_peer_discovery: default_allow_discovery(),
-            snapshot_server_port: default_snapshot_server_port(),
-            snapshot_dir: default_snapshot_dir(),
+            storage_endpoint_address: None,
         }
     }
 

--- a/tests/transport_tests.rs
+++ b/tests/transport_tests.rs
@@ -26,8 +26,7 @@ fn create_test_config(node_id: u64, port: u16, peers: Vec<PeerInfo>) -> NetworkC
         connection_timeout_ms: 10000,
         max_retries: 3,
         allow_peer_discovery: true,
-        snapshot_server_port: 8082, // Default test snapshot server port
-        snapshot_dir: format!("./data/test_snapshots/{}", node_id), // Test snapshot directory
+        storage_endpoint_address: None, // No endpoint address in tests
     }
 }
 


### PR DESCRIPTION
### Task 4: Update NetworkConfig 
**Priority: Medium**
**Estimated Effort: 1 hour**

Sub-tasks:
1. Remove `snapshot_server_port` from `NetworkConfig`
2. Remove `snapshot_dir` from `NetworkConfig`  
3. Add `storage_endpoint_address: Option<String>` for peers to know where to download from
4. Update tests to reflect changes

Files to modify:
- `src/transport/libp2p_network.rs`
- `tests/transport_tests.rs`
